### PR TITLE
issue #273

### DIFF
--- a/SuperPutty/Utils/CommandData.cs
+++ b/SuperPutty/Utils/CommandData.cs
@@ -23,6 +23,11 @@ namespace SuperPutty.Utils
 
         public void SendToTerminal(int handle)
         {
+            SendToTerminal(handle, true);
+        }
+
+        public void SendToTerminal(int handle, bool enter)
+        {
             if (!string.IsNullOrEmpty(this.Command))
             {
                 // send normal string command
@@ -30,7 +35,10 @@ namespace SuperPutty.Utils
                 {
                     NativeMethods.SendMessage(handle, NativeMethods.WM_CHAR, (int)c, 0);
                 }
-                NativeMethods.SendMessage(handle, NativeMethods.WM_CHAR, (int)Keys.Enter, 0);
+                if (enter)
+                {
+                    NativeMethods.SendMessage(handle, NativeMethods.WM_CHAR, (int)Keys.Enter, 0);
+                }
             }
             else if (this.KeyData != null)
             {
@@ -44,7 +52,7 @@ namespace SuperPutty.Utils
                 if (this.KeyData.Shift) { NativeMethods.PostMessage(handle, NativeMethods.WM_KEYUP, NativeMethods.VK_SHIFT, 0); }
                 if (this.KeyData.Control) { NativeMethods.PostMessage(handle, NativeMethods.WM_KEYUP, NativeMethods.VK_CONTROL, 0); }
             }
-            else
+            else if (enter)
             {
                 NativeMethods.SendMessage(handle, NativeMethods.WM_CHAR, (int)Keys.Enter, 0);
             }

--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -1007,7 +1007,7 @@ namespace SuperPutty
             else if (e.KeyCode == Keys.Enter)
             {
                 // send commands
-                TrySendCommandsFromToolbar(new CommandData(this.tsSendCommandCombo.Text), !this.tbBtnMaskText.Checked);
+                TrySendCommandsFromToolbar(new CommandData(this.tsSendCommandCombo.Text), !this.tbBtnMaskText.Checked, !e.Shift);
                 e.Handled = true;
                 e.SuppressKeyPress = true;
             }
@@ -1047,10 +1047,20 @@ namespace SuperPutty
 
         int TrySendCommandsFromToolbar(bool saveHistory)
         {
-            return TrySendCommandsFromToolbar(new CommandData(this.tsSendCommandCombo.Text), saveHistory);
+            return TrySendCommandsFromToolbar(new CommandData(this.tsSendCommandCombo.Text), saveHistory, true);
+        }
+
+        int TrySendCommandsFromToolbar(bool saveHistory, bool enter)
+        {
+            return TrySendCommandsFromToolbar(new CommandData(this.tsSendCommandCombo.Text), saveHistory, enter);
         }
 
         int TrySendCommandsFromToolbar(CommandData command, bool saveHistory)
+        {
+            return TrySendCommandsFromToolbar(command, saveHistory, true);
+        }
+
+        int TrySendCommandsFromToolbar(CommandData command, bool saveHistory, bool enter)
         {
             int sent = 0;
             if (this.DockPanel.DocumentsCount > 0)
@@ -1063,7 +1073,7 @@ namespace SuperPutty
                         int handle = puttyPanel.AppPanel.AppWindowHandle.ToInt32();
                         Log.InfoFormat("SendCommand: session={0}, command=[{1}], handle={2}", puttyPanel.Session.SessionId, command, handle);
                         
-                        command.SendToTerminal(handle);
+                        command.SendToTerminal(handle, enter);
                         
                         sent++;
                     }


### PR DESCRIPTION
pressing shift-enter in the command sender will suppress the trailing enter key in the
commands actually sent to the putty sessions.  pressing enter by itself will still function as
normal.