### PR TITLE
Reset Terminal and Clear Scrollback Menu Item

### DIFF
--- a/SuperPutty/ctlPuttyPanel.Designer.cs
+++ b/SuperPutty/ctlPuttyPanel.Designer.cs
@@ -44,6 +44,7 @@
             this.restartSessionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.clearScrollbackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resetTerminalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resetAndClearScrollbackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.aboutPuttyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
@@ -71,6 +72,7 @@
             this.restartSessionToolStripMenuItem,
             this.clearScrollbackToolStripMenuItem,
             this.resetTerminalToolStripMenuItem,
+            this.resetAndClearScrollbackToolStripMenuItem,
             this.toolStripSeparator3,
             this.aboutPuttyToolStripMenuItem,
             this.toolStripSeparator4,
@@ -79,19 +81,19 @@
             this.closeOthersToTheRightToolStripMenuItem,
             this.closeAllToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(207, 408);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(262, 430);
             this.contextMenuStrip1.Opening += new System.ComponentModel.CancelEventHandler(this.contextMenuStrip1_Opening);
             // 
             // newSessionToolStripMenuItem
             // 
             this.newSessionToolStripMenuItem.Name = "newSessionToolStripMenuItem";
-            this.newSessionToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.newSessionToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.newSessionToolStripMenuItem.Text = "New Session";
             // 
             // duplicateSessionToolStripMenuItem
             // 
             this.duplicateSessionToolStripMenuItem.Name = "duplicateSessionToolStripMenuItem";
-            this.duplicateSessionToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.duplicateSessionToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.duplicateSessionToolStripMenuItem.Text = "Duplicate Session";
             this.duplicateSessionToolStripMenuItem.Click += new System.EventHandler(this.duplicateSessionToolStripMenuItem_Click);
             // 
@@ -99,19 +101,19 @@
             // 
             this.toolStripSeparator1.BackColor = System.Drawing.Color.Red;
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(203, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(258, 6);
             // 
             // renameTabToolStripMenuItem
             // 
             this.renameTabToolStripMenuItem.Name = "renameTabToolStripMenuItem";
-            this.renameTabToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.renameTabToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.renameTabToolStripMenuItem.Text = "Rename Tab";
             this.renameTabToolStripMenuItem.Click += new System.EventHandler(this.renameTabToolStripMenuItem_Click);
             // 
             // refreshToolStripMenuItem
             // 
             this.refreshToolStripMenuItem.Name = "refreshToolStripMenuItem";
-            this.refreshToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.refreshToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.refreshToolStripMenuItem.Text = "Refresh Tab";
             this.refreshToolStripMenuItem.Click += new System.EventHandler(this.refreshToolStripMenuItem_Click);
             // 
@@ -121,18 +123,18 @@
             this.acceptCommandsToolStripMenuItem.CheckOnClick = true;
             this.acceptCommandsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.acceptCommandsToolStripMenuItem.Name = "acceptCommandsToolStripMenuItem";
-            this.acceptCommandsToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.acceptCommandsToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.acceptCommandsToolStripMenuItem.Text = "Accept Commands";
             // 
             // toolStripPuttySep1
             // 
             this.toolStripPuttySep1.Name = "toolStripPuttySep1";
-            this.toolStripPuttySep1.Size = new System.Drawing.Size(203, 6);
+            this.toolStripPuttySep1.Size = new System.Drawing.Size(258, 6);
             // 
             // eventLogToolStripMenuItem
             // 
             this.eventLogToolStripMenuItem.Name = "eventLogToolStripMenuItem";
-            this.eventLogToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.eventLogToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.eventLogToolStripMenuItem.Tag = "0x0010";
             this.eventLogToolStripMenuItem.Text = "Event Log";
             this.eventLogToolStripMenuItem.Click += new System.EventHandler(this.puTTYMenuTSMI_Click);
@@ -140,12 +142,12 @@
             // toolStripPuttySep2
             // 
             this.toolStripPuttySep2.Name = "toolStripPuttySep2";
-            this.toolStripPuttySep2.Size = new System.Drawing.Size(203, 6);
+            this.toolStripPuttySep2.Size = new System.Drawing.Size(258, 6);
             // 
             // changeSettingsToolStripMenuItem
             // 
             this.changeSettingsToolStripMenuItem.Name = "changeSettingsToolStripMenuItem";
-            this.changeSettingsToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.changeSettingsToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.changeSettingsToolStripMenuItem.Tag = "0x0050";
             this.changeSettingsToolStripMenuItem.Text = "Change Settings";
             this.changeSettingsToolStripMenuItem.Click += new System.EventHandler(this.puTTYMenuTSMI_Click);
@@ -153,7 +155,7 @@
             // copyAllToClipboardToolStripMenuItem
             // 
             this.copyAllToClipboardToolStripMenuItem.Name = "copyAllToClipboardToolStripMenuItem";
-            this.copyAllToClipboardToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.copyAllToClipboardToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.copyAllToClipboardToolStripMenuItem.Tag = "0x0170";
             this.copyAllToClipboardToolStripMenuItem.Text = "Copy All to Clipboard";
             this.copyAllToClipboardToolStripMenuItem.Click += new System.EventHandler(this.puTTYMenuTSMI_Click);
@@ -161,7 +163,7 @@
             // restartSessionToolStripMenuItem
             // 
             this.restartSessionToolStripMenuItem.Name = "restartSessionToolStripMenuItem";
-            this.restartSessionToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.restartSessionToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.restartSessionToolStripMenuItem.Tag = "0x0040";
             this.restartSessionToolStripMenuItem.Text = "Restart Session";
             this.restartSessionToolStripMenuItem.Click += new System.EventHandler(this.puTTYMenuTSMI_Click);
@@ -169,7 +171,7 @@
             // clearScrollbackToolStripMenuItem
             // 
             this.clearScrollbackToolStripMenuItem.Name = "clearScrollbackToolStripMenuItem";
-            this.clearScrollbackToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.clearScrollbackToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.clearScrollbackToolStripMenuItem.Tag = "0x0060";
             this.clearScrollbackToolStripMenuItem.Text = "Clear Scrollback";
             this.clearScrollbackToolStripMenuItem.Click += new System.EventHandler(this.puTTYMenuTSMI_Click);
@@ -177,53 +179,61 @@
             // resetTerminalToolStripMenuItem
             // 
             this.resetTerminalToolStripMenuItem.Name = "resetTerminalToolStripMenuItem";
-            this.resetTerminalToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.resetTerminalToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.resetTerminalToolStripMenuItem.Tag = "0x0070";
             this.resetTerminalToolStripMenuItem.Text = "Reset Terminal";
             this.resetTerminalToolStripMenuItem.Click += new System.EventHandler(this.puTTYMenuTSMI_Click);
             // 
+            // resetAndClearScrollbackToolStripMenuItem
+            // 
+            this.resetAndClearScrollbackToolStripMenuItem.Name = "resetAndClearScrollbackToolStripMenuItem";
+            this.resetAndClearScrollbackToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
+            this.resetAndClearScrollbackToolStripMenuItem.Tag = "0x0070;0x0060";
+            this.resetAndClearScrollbackToolStripMenuItem.Text = "Reset Terminal and Clear Scrollback";
+            this.resetAndClearScrollbackToolStripMenuItem.Click += new System.EventHandler(this.puTTYMenuTSMI_Click);
+            // 
             // toolStripSeparator3
             // 
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(203, 6);
+            this.toolStripSeparator3.Size = new System.Drawing.Size(258, 6);
             // 
             // aboutPuttyToolStripMenuItem
             // 
             this.aboutPuttyToolStripMenuItem.Name = "aboutPuttyToolStripMenuItem";
-            this.aboutPuttyToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.aboutPuttyToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.aboutPuttyToolStripMenuItem.Text = "About Putty";
             this.aboutPuttyToolStripMenuItem.Click += new System.EventHandler(this.aboutPuttyToolStripMenuItem_Click);
             // 
             // toolStripSeparator4
             // 
             this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(203, 6);
+            this.toolStripSeparator4.Size = new System.Drawing.Size(258, 6);
             // 
             // closeSessionToolStripMenuItem
             // 
             this.closeSessionToolStripMenuItem.Name = "closeSessionToolStripMenuItem";
-            this.closeSessionToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.closeSessionToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.closeSessionToolStripMenuItem.Text = "Close";
             this.closeSessionToolStripMenuItem.Click += new System.EventHandler(this.closeSessionToolStripMenuItem_Click);
             // 
             // closeOthersToolStripMenuItem
             // 
             this.closeOthersToolStripMenuItem.Name = "closeOthersToolStripMenuItem";
-            this.closeOthersToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.closeOthersToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.closeOthersToolStripMenuItem.Text = "Close Others ";
             this.closeOthersToolStripMenuItem.Click += new System.EventHandler(this.closeOthersToolStripMenuItem_Click);
             // 
             // closeOthersToTheRightToolStripMenuItem
             // 
             this.closeOthersToTheRightToolStripMenuItem.Name = "closeOthersToTheRightToolStripMenuItem";
-            this.closeOthersToTheRightToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.closeOthersToTheRightToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.closeOthersToTheRightToolStripMenuItem.Text = "Close Others to the Right";
             this.closeOthersToTheRightToolStripMenuItem.Click += new System.EventHandler(this.closeOthersToTheRightToolStripMenuItem_Click);
             // 
             // closeAllToolStripMenuItem
             // 
             this.closeAllToolStripMenuItem.Name = "closeAllToolStripMenuItem";
-            this.closeAllToolStripMenuItem.Size = new System.Drawing.Size(206, 22);
+            this.closeAllToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
             this.closeAllToolStripMenuItem.Text = "Close All";
             this.closeAllToolStripMenuItem.Click += new System.EventHandler(this.closeAllToolStripMenuItem_Click);
             // 
@@ -265,6 +275,7 @@
         private System.Windows.Forms.ToolStripMenuItem closeOthersToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem closeOthersToTheRightToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem closeAllToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resetAndClearScrollbackToolStripMenuItem;
 
     }
 }

--- a/SuperPutty/ctlPuttyPanel.cs
+++ b/SuperPutty/ctlPuttyPanel.cs
@@ -463,7 +463,7 @@ namespace SuperPutty
                 try
                 {
                     this.SetFocusToChildApplication("MenuHandler");
-                    for (int i = 0; i < tags.Length; ++i)
+                    for (int i = 0; i < commands.Length; ++i)
                     {
                         NativeMethods.SendMessage(m_AppPanel.AppWindowHandle, (uint)NativeMethods.WM.SYSCOMMAND, commands[i], 0);
                     }

--- a/SuperPutty/ctlPuttyPanel.cs
+++ b/SuperPutty/ctlPuttyPanel.cs
@@ -450,16 +450,23 @@ namespace SuperPutty
         private void puTTYMenuTSMI_Click(object sender, EventArgs e)
         {
             ToolStripMenuItem menuItem = (ToolStripMenuItem) sender;
-            string tag = ((ToolStripMenuItem)sender).Tag.ToString();
-            uint command = Convert.ToUInt32(tag, 16);
+            string[] tags = ((ToolStripMenuItem)sender).Tag.ToString().Split(';');
+            uint[] commands = new uint[tags.Length];
+            for (int i = 0; i < tags.Length; ++i)
+            {
+                commands[i] = Convert.ToUInt32(tags[i], 16);
+                Log.DebugFormat("Sending Putty Command: menu={2}, tag={0}, command={1}", tags[i], commands[i], menuItem.Text);
+            }
 
-            Log.DebugFormat("Sending Putty Command: menu={2}, tag={0}, command={1}", tag, command, menuItem.Text);
             ThreadPool.QueueUserWorkItem(delegate
             {
                 try
                 {
                     this.SetFocusToChildApplication("MenuHandler");
-                    NativeMethods.SendMessage(m_AppPanel.AppWindowHandle, (uint)NativeMethods.WM.SYSCOMMAND, command, 0);
+                    for (int i = 0; i < tags.Length; ++i)
+                    {
+                        NativeMethods.SendMessage(m_AppPanel.AppWindowHandle, (uint)NativeMethods.WM.SYSCOMMAND, commands[i], 0);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This is a pull request to add the ‘Reset Terminal and Clear Scrollback’ menu item to SuperPutty. Personally, I often need to execute commands with a lot of output that I may want to copy to my clipboard for some reason (ex: search for something in the output of the command). Every time that I want to do this, I always have to reset the terminal and then clear the scrollback which is pretty annoying. So, I added this context menu item that executes a reset of the terminal and then clears the scrollback.

![image](https://cloud.githubusercontent.com/assets/14843898/14758067/81655a92-08c8-11e6-8130-381266aad89e.png)
