### PR TITLE
Add VNC viewer support for SuperPuTTY

### DIFF
--- a/SuperPutty/App.config
+++ b/SuperPutty/App.config
@@ -223,11 +223,16 @@
       </setting>
       <setting name="SessiontreeShowFoldersFirst" serializeAs="String">
         <value>False</value>
-      </setting>      <setting name="FileZillaExe" serializeAs="String">
+      </setting>
+      <setting name="FileZillaExe" serializeAs="String">
         <value />
       </setting>
       <setting name="WinSCPExe" serializeAs="String">
         <value />
-      </setting>    </SuperPutty.Properties.Settings>
+      </setting>
+      <setting name="VNCExe" serializeAs="String">
+        <value />
+      </setting>
+    </SuperPutty.Properties.Settings>
   </userSettings>
 <startup><supportedRuntime version="v2.0.50727"/></startup></configuration>

--- a/SuperPutty/Data/SessionData.cs
+++ b/SuperPutty/Data/SessionData.cs
@@ -44,7 +44,8 @@ namespace SuperPutty.Data
         Raw,
         Serial,
         Cygterm,
-        Mintty
+        Mintty,
+        VNC
     }
 
     /// <summary>The main class containing configuration settings for a session</summary>
@@ -535,10 +536,16 @@ namespace SuperPutty.Data
             {
                 return string.Format("{0}://{1}", this.Proto.ToString().ToLower(), this.Host);
             }
-            else
+
+            if (this.Proto == ConnectionProtocol.VNC)
             {
-                return string.Format("{0}://{1}:{2}", this.Proto.ToString().ToLower(), this.Host, this.Port);
+                if (this.Port == 0)
+                    return string.Format("{0}://{1}", this.Proto.ToString().ToLower(), this.Host);
+                else
+                    return string.Format("{0}://{1}::{2}", this.Proto.ToString().ToLower(), this.Host, this.Port);
             }
+
+            return string.Format("{0}://{1}:{2}", this.Proto.ToString().ToLower(), this.Host, this.Port);
         }
 
         class PuttySessionConverter : StringConverter

--- a/SuperPutty/Properties/Settings.Designer.cs
+++ b/SuperPutty/Properties/Settings.Designer.cs
@@ -247,6 +247,19 @@ namespace SuperPutty.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Configuration.SettingsProviderAttribute(typeof(SuperPutty.Utils.PortableSettingsProvider))]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string VNCExe {
+            get {
+                return ((string)(this["VNCExe"]));
+            }
+            set {
+                this["VNCExe"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Configuration.SettingsProviderAttribute(typeof(SuperPutty.Utils.PortableSettingsProvider))]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Static")]
         public string TabTextBehavior {
             get {

--- a/SuperPutty/Properties/Settings.settings
+++ b/SuperPutty/Properties/Settings.settings
@@ -53,6 +53,9 @@
     <Setting Name="MinttyExe" Provider="SuperPutty.Utils.PortableSettingsProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="VNCExe" Provider="SuperPutty.Utils.PortableSettingsProvider" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
     <Setting Name="TabTextBehavior" Provider="SuperPutty.Utils.PortableSettingsProvider" Type="System.String" Scope="User">
       <Value Profile="(Default)">Static</Value>
     </Setting>

--- a/SuperPutty/SuperPuTTY.cs
+++ b/SuperPutty/SuperPuTTY.cs
@@ -435,6 +435,25 @@ namespace SuperPutty
             ctlPuttyPanel panel = null;
             if (session != null)
             {
+                String Executable = PuttyStartInfo.GetExecutable(session);
+                if (String.IsNullOrEmpty(Executable))
+                {
+                    MessageBox.Show("Error trying to create session: " + session.ToString() +
+                        "\nExecutable not set for " + session.Proto.ToString() + " protocol." +
+                        "\nGo to tools->options->General tab to set the path to the executable."
+                        , "Failed to create a session", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return null;
+                }
+                if (!File.Exists(Executable))
+                {
+                    MessageBox.Show("Error trying to create session: " + session.ToString() +
+                        "\nExecutable not found for " + session.Proto.ToString() + " protocol." +
+                        "\nThe path for the executable was set as \"" + Executable + "\"." +
+                        "\nGo to tools->options->General tab to set the path to the executable."
+                        , "Failed to create a session", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return null;
+                }
+
                 // This is the callback fired when the panel containing the terminal is closed
                 // We use this to save the last docking location and to close the panel
                 PuttyClosedCallback callback = delegate

--- a/SuperPutty/SuperPutty.csproj
+++ b/SuperPutty/SuperPutty.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Utils\GlobalWindowEvents.cs" />
     <Compile Include="Utils\HostConnectionString.cs" />
     <Compile Include="Utils\MinttyStartInfo.cs" />
+    <Compile Include="Utils\VNCStartInfo.cs" />
     <Compile Include="Utils\NativeMethods.cs" />
     <Compile Include="Utils\PortableSettingsProvider.cs" />
     <Compile Include="Utils\PropertyNotifiableObject.cs" />

--- a/SuperPutty/Utils/CommandLineOptions.cs
+++ b/SuperPutty/Utils/CommandLineOptions.cs
@@ -20,12 +20,12 @@ namespace SuperPutty.Utils
     /// SuperPutty.exe -l USER -pw PASSWORD -load SETTINGS PROTOCOL://HOSTNAME:port
     /// ------------
     /// Options:
-    /// -ssh|-serial|-telnet|-scp|-raw|-rlogin|-cygterm   -Choose Protocol (default: ssh)
-    /// -P                                                -Port            (default: 22)
-    /// -l                                                -Login Name
-    /// -pw                                               -Login Password
-    /// -load                                             -Session to load (default: Default Session)
-    /// --------------------------------------------------------------------------
+    /// -ssh|-serial|-telnet|-scp|-raw|-rlogin|-cygterm|-vnc  -Choose Protocol (default: ssh)
+    /// -P                                                    -Port            (default: 22)
+    /// -l                                                    -Login Name
+    /// -pw                                                   -Login Password
+    /// -load                                                 -Session to load (default: Default Session)
+    /// ------------------------------------------------------------------------------
     /// SuperPutty.exe -layout LAYOUT_NAME
     /// SuperPutty.exe -session SESSION_ID
     /// SuperPutty.exe -ssh -P 22 -l homer -pw springfield -load pp1 prod-reactor
@@ -98,6 +98,9 @@ namespace SuperPutty.Utils
                         break;
                     case "-cygterm":
                         this.Protocol = ConnectionProtocol.Cygterm;
+                        break;
+                    case "-vnc":
+                        this.Protocol = ConnectionProtocol.VNC;
                         break;
                     case "-scp":
                         this.UseScp = true;
@@ -262,7 +265,7 @@ namespace SuperPutty.Utils
             sb.AppendLine("  SESSION\t\t - Session id");
             sb.AppendLine("  LAYOUT\t\t - Layout name");
             sb.AppendLine("  SETTINGS\t - Putty Saved Session Profile");
-            sb.AppendLine("  PROTO\t\t - Protocol - (ssh|ssh2|telnet|serial|raw|scp|cygterm|rlogin|mintty)");
+            sb.AppendLine("  PROTO\t\t - Protocol - (ssh|ssh2|telnet|serial|raw|scp|cygterm|rlogin|mintty|vnc)");
             sb.AppendLine("  USER\t\t - User name");
             sb.AppendLine("  PASSWORD\t - Login Password");
             sb.AppendLine("  HOST\t\t - Hostname");
@@ -272,6 +275,7 @@ namespace SuperPutty.Utils
             sb.AppendLine("  SuperPutty.exe -session nyc-qa-1");
             sb.AppendLine("  SuperPutty.exe -layout prod");
             sb.AppendLine("  SuperPutty.exe -ssh -P 22 -l homer -pw springfield -load pp1 prod-reactor");
+            sb.AppendLine("  SuperPutty.exe -vnc stewie01");
             sb.AppendLine("  SuperPutty.exe -l peter -pw griffin stewie01");
             sb.AppendLine("  SuperPutty.exe -load localhost");
             

--- a/SuperPutty/Utils/HostConnectionString.cs
+++ b/SuperPutty/Utils/HostConnectionString.cs
@@ -11,7 +11,7 @@ namespace SuperPutty.Utils
     {
         private static readonly ILog log = LogManager.GetLogger(typeof(HostConnectionString));
 
-        public HostConnectionString(string hostString)
+        public HostConnectionString(string hostString, bool ignorePort = false)
         {
 
             int idx = hostString.IndexOf("://");
@@ -35,7 +35,7 @@ namespace SuperPutty.Utils
             {
                 // localhost:2020
                 int port;
-                if (int.TryParse(hostPort.Substring(idxPort + 1), out port))
+                if (!ignorePort && (int.TryParse(hostPort.Substring(idxPort + 1), out port)))
                 {
                     this.Host = hostPort.Substring(0, idxPort);
                     this.Port = port;

--- a/SuperPutty/Utils/PuttyStartInfo.cs
+++ b/SuperPutty/Utils/PuttyStartInfo.cs
@@ -14,11 +14,26 @@ namespace SuperPutty.Utils
 
         private static readonly Regex regExEnvVars = new Regex(@"(%\w+%)");
 
+        public static String GetExecutable(SessionData session)
+        {
+            switch (session.Proto)
+            {
+                case ConnectionProtocol.Mintty:
+                    return TryParseEnvVars(SuperPuTTY.Settings.MinttyExe);
+
+                case ConnectionProtocol.VNC:
+                    return TryParseEnvVars(SuperPuTTY.Settings.VNCExe);
+
+                default:
+                    return TryParseEnvVars(SuperPuTTY.Settings.PuttyExe);
+            }
+        }
+
         public PuttyStartInfo(SessionData session)
         {
             string argsToLog = null;
 
-            this.Executable = SuperPuTTY.Settings.PuttyExe;
+            this.Executable = GetExecutable(session);
 
             if (session.Proto == ConnectionProtocol.Cygterm)
             {
@@ -31,7 +46,12 @@ namespace SuperPutty.Utils
                 MinttyStartInfo mintty = new MinttyStartInfo(session);
                 this.Args = mintty.Args;
                 this.WorkingDir = mintty.StartingDir;
-                this.Executable = SuperPuTTY.Settings.MinttyExe;
+            }
+            else if (session.Proto == ConnectionProtocol.VNC)
+            {
+                VNCStartInfo vnc = new VNCStartInfo(session);
+                this.Args = vnc.Args;
+                this.WorkingDir = vnc.StartingDir;
             }
             else
             {

--- a/SuperPutty/Utils/VNCStartinfo.cs
+++ b/SuperPutty/Utils/VNCStartinfo.cs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017 Anish Sane https://stackoverflow.com/users/793796/anishsane
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions: 
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using log4net;
+using SuperPutty.Data;
+using System.Text.RegularExpressions;
+using System.IO;
+
+namespace SuperPutty.Utils
+{
+
+    /// <summary>
+    /// Helper class for VNC support
+    /// </summary>
+    public class VNCStartInfo
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(VNCStartInfo));
+
+        private SessionData session;
+
+        public VNCStartInfo(SessionData session)
+        {
+            this.session = session;
+            this.Args = "-scale=auto ";
+
+            if (session.Port != 0)
+                this.Args += "-port=" + session.Port.ToString() + " ";
+
+            if (!String.IsNullOrEmpty(session.Password))
+                this.Args += "-password=\"" + session.Password + "\" ";
+
+            if (!String.IsNullOrEmpty(session.ExtraArgs))
+                this.Args += session.ExtraArgs + " ";
+
+            this.Args += "\"" + session.Host + "\"";
+
+            this.StartingDir = "%userprofile%\\Desktop";
+        }
+
+        public string Args { get; set; }
+        public string StartingDir { get; set; }
+
+    }
+}

--- a/SuperPutty/dlgEditSession.Designer.cs
+++ b/SuperPutty/dlgEditSession.Designer.cs
@@ -37,6 +37,7 @@ namespace SuperPutty
             this.label3 = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.radioButtonMintty = new System.Windows.Forms.RadioButton();
+            this.radioButtonVNC = new System.Windows.Forms.RadioButton();
             this.radioButtonCygterm = new System.Windows.Forms.RadioButton();
             this.radioButtonSerial = new System.Windows.Forms.RadioButton();
             this.radioButtonSSH = new System.Windows.Forms.RadioButton();
@@ -79,7 +80,7 @@ namespace SuperPutty
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxSessionName.Location = new System.Drawing.Point(6, 33);
             this.textBoxSessionName.Name = "textBoxSessionName";
-            this.textBoxSessionName.Size = new System.Drawing.Size(416, 20);
+            this.textBoxSessionName.Size = new System.Drawing.Size(464, 20);
             this.textBoxSessionName.TabIndex = 0;
             this.textBoxSessionName.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxSessionName_Validating);
             this.textBoxSessionName.Validated += new System.EventHandler(this.textBoxSessionName_Validated);
@@ -110,14 +111,14 @@ namespace SuperPutty
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxHostname.Location = new System.Drawing.Point(6, 74);
             this.textBoxHostname.Name = "textBoxHostname";
-            this.textBoxHostname.Size = new System.Drawing.Size(316, 20);
+            this.textBoxHostname.Size = new System.Drawing.Size(361, 20);
             this.textBoxHostname.TabIndex = 1;
             this.textBoxHostname.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxHostname_Validating);
             // 
             // textBoxPort
             // 
             this.textBoxPort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxPort.Location = new System.Drawing.Point(345, 74);
+            this.textBoxPort.Location = new System.Drawing.Point(390, 74);
             this.textBoxPort.Name = "textBoxPort";
             this.textBoxPort.Size = new System.Drawing.Size(80, 20);
             this.textBoxPort.TabIndex = 2;
@@ -130,16 +131,17 @@ namespace SuperPutty
             this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(342, 56);
+            this.label3.Location = new System.Drawing.Point(387, 56);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(29, 15);
             this.label3.TabIndex = 5;
-            this.label3.Text = "Port";
+            this.label3.Text = "TCP Port";
             // 
             // groupBox1
             // 
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox1.Controls.Add(this.radioButtonVNC);
             this.groupBox1.Controls.Add(this.radioButtonMintty);
             this.groupBox1.Controls.Add(this.radioButtonCygterm);
             this.groupBox1.Controls.Add(this.radioButtonSerial);
@@ -150,10 +152,23 @@ namespace SuperPutty
             this.groupBox1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.groupBox1.Location = new System.Drawing.Point(14, 117);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(440, 49);
+            this.groupBox1.Size = new System.Drawing.Size(485, 49);
             this.groupBox1.TabIndex = 3;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Connection type:";
+            // 
+            // radioButtonVNC
+            // 
+            this.radioButtonVNC.AutoSize = true;
+            this.radioButtonVNC.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.radioButtonVNC.Location = new System.Drawing.Point(432, 19);
+            this.radioButtonVNC.Name = "radioButtonVNC";
+            this.radioButtonVNC.Size = new System.Drawing.Size(60, 19);
+            this.radioButtonVNC.TabIndex = 9;
+            this.radioButtonVNC.Tag = SuperPutty.Data.ConnectionProtocol.VNC;
+            this.radioButtonVNC.Text = "VNC";
+            this.radioButtonVNC.UseVisualStyleBackColor = true;
+            this.radioButtonVNC.CheckedChanged += new System.EventHandler(this.radioButtonVNC_CheckedChanged);
             // 
             // radioButtonMintty
             // 
@@ -253,7 +268,7 @@ namespace SuperPutty
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxExtraArgs.Location = new System.Drawing.Point(150, 229);
             this.textBoxExtraArgs.Name = "textBoxExtraArgs";
-            this.textBoxExtraArgs.Size = new System.Drawing.Size(304, 20);
+            this.textBoxExtraArgs.Size = new System.Drawing.Size(349, 20);
             this.textBoxExtraArgs.TabIndex = 6;
             this.textBoxExtraArgs.TextChanged += new System.EventHandler(this.textBoxExtraArgs_TextChanged);
             // 
@@ -270,7 +285,7 @@ namespace SuperPutty
             // buttonSave
             // 
             this.buttonSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonSave.Location = new System.Drawing.Point(298, 401);
+            this.buttonSave.Location = new System.Drawing.Point(343, 401);
             this.buttonSave.Name = "buttonSave";
             this.buttonSave.Size = new System.Drawing.Size(75, 23);
             this.buttonSave.TabIndex = 8;
@@ -283,7 +298,7 @@ namespace SuperPutty
             this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.CausesValidation = false;
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(379, 401);
+            this.buttonCancel.Location = new System.Drawing.Point(424, 401);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
             this.buttonCancel.TabIndex = 9;
@@ -308,7 +323,7 @@ namespace SuperPutty
             this.comboBoxPuttyProfile.FormattingEnabled = true;
             this.comboBoxPuttyProfile.Location = new System.Drawing.Point(150, 176);
             this.comboBoxPuttyProfile.Name = "comboBoxPuttyProfile";
-            this.comboBoxPuttyProfile.Size = new System.Drawing.Size(304, 21);
+            this.comboBoxPuttyProfile.Size = new System.Drawing.Size(349, 21);
             this.comboBoxPuttyProfile.TabIndex = 4;
             this.comboBoxPuttyProfile.SelectedIndexChanged += new System.EventHandler(this.comboBoxPuttyProfile_SelectedIndexChanged);
             this.comboBoxPuttyProfile.Validating += new System.ComponentModel.CancelEventHandler(this.comboBoxPuttyProfile_Validating);
@@ -325,7 +340,7 @@ namespace SuperPutty
             this.groupBox2.Controls.Add(this.textBoxPort);
             this.groupBox2.Location = new System.Drawing.Point(14, 5);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(440, 109);
+            this.groupBox2.Size = new System.Drawing.Size(485, 109);
             this.groupBox2.TabIndex = 11;
             this.groupBox2.TabStop = false;
             // 
@@ -345,7 +360,7 @@ namespace SuperPutty
             | System.Windows.Forms.AnchorStyles.Right)));
             this.textBoxUsername.Location = new System.Drawing.Point(150, 203);
             this.textBoxUsername.Name = "textBoxUsername";
-            this.textBoxUsername.Size = new System.Drawing.Size(304, 20);
+            this.textBoxUsername.Size = new System.Drawing.Size(349, 20);
             this.textBoxUsername.TabIndex = 5;
             // 
             // errorProvider
@@ -364,7 +379,8 @@ namespace SuperPutty
             // 
             // buttonBrowse
             // 
-            this.buttonBrowse.Location = new System.Drawing.Point(379, 253);
+            this.buttonBrowse.Location = new System.Drawing.Point(424, 253);
+            this.buttonBrowse.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right);
             this.buttonBrowse.Name = "buttonBrowse";
             this.buttonBrowse.Size = new System.Drawing.Size(75, 23);
             this.buttonBrowse.TabIndex = 15;
@@ -375,8 +391,9 @@ namespace SuperPutty
             // textBoxSPSLScriptFile
             // 
             this.textBoxSPSLScriptFile.Location = new System.Drawing.Point(150, 255);
+            this.textBoxSPSLScriptFile.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right);
             this.textBoxSPSLScriptFile.Name = "textBoxSPSLScriptFile";
-            this.textBoxSPSLScriptFile.Size = new System.Drawing.Size(142, 20);
+            this.textBoxSPSLScriptFile.Size = new System.Drawing.Size(187, 20);
             this.textBoxSPSLScriptFile.TabIndex = 16;
             // 
             // label7
@@ -396,7 +413,8 @@ namespace SuperPutty
             // 
             // buttonClearSPSLFile
             // 
-            this.buttonClearSPSLFile.Location = new System.Drawing.Point(298, 253);
+            this.buttonClearSPSLFile.Location = new System.Drawing.Point(343, 253);
+            this.buttonClearSPSLFile.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right);
             this.buttonClearSPSLFile.Name = "buttonClearSPSLFile";
             this.buttonClearSPSLFile.Size = new System.Drawing.Size(75, 23);
             this.buttonClearSPSLFile.TabIndex = 18;
@@ -413,8 +431,9 @@ namespace SuperPutty
             this.groupBoxFileTransferOptions.Controls.Add(this.lbLocalPath);
             this.groupBoxFileTransferOptions.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.groupBoxFileTransferOptions.Location = new System.Drawing.Point(14, 289);
+            this.groupBoxFileTransferOptions.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right);
             this.groupBoxFileTransferOptions.Name = "groupBoxFileTransferOptions";
-            this.groupBoxFileTransferOptions.Size = new System.Drawing.Size(440, 100);
+            this.groupBoxFileTransferOptions.Size = new System.Drawing.Size(485, 100);
             this.groupBoxFileTransferOptions.TabIndex = 19;
             this.groupBoxFileTransferOptions.TabStop = false;
             this.groupBoxFileTransferOptions.Text = "File Transfer Options";
@@ -422,8 +441,9 @@ namespace SuperPutty
             // textBoxRemotePathSesion
             // 
             this.textBoxRemotePathSesion.Location = new System.Drawing.Point(91, 61);
+            this.textBoxRemotePathSesion.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right);
             this.textBoxRemotePathSesion.Name = "textBoxRemotePathSesion";
-            this.textBoxRemotePathSesion.Size = new System.Drawing.Size(334, 23);
+            this.textBoxRemotePathSesion.Size = new System.Drawing.Size(379, 23);
             this.textBoxRemotePathSesion.TabIndex = 18;
             // 
             // lbRemotePath
@@ -437,7 +457,8 @@ namespace SuperPutty
             // 
             // buttonBrowseLocalPath
             // 
-            this.buttonBrowseLocalPath.Location = new System.Drawing.Point(350, 28);
+            this.buttonBrowseLocalPath.Location = new System.Drawing.Point(395, 28);
+            this.buttonBrowseLocalPath.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right);
             this.buttonBrowseLocalPath.Name = "buttonBrowseLocalPath";
             this.buttonBrowseLocalPath.Size = new System.Drawing.Size(75, 23);
             this.buttonBrowseLocalPath.TabIndex = 16;
@@ -448,8 +469,9 @@ namespace SuperPutty
             // textBoxLocalPathSesion
             // 
             this.textBoxLocalPathSesion.Location = new System.Drawing.Point(90, 29);
+            this.textBoxLocalPathSesion.Anchor = (System.Windows.Forms.AnchorStyles)(System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right);
             this.textBoxLocalPathSesion.Name = "textBoxLocalPathSesion";
-            this.textBoxLocalPathSesion.Size = new System.Drawing.Size(249, 23);
+            this.textBoxLocalPathSesion.Size = new System.Drawing.Size(294, 23);
             this.textBoxLocalPathSesion.TabIndex = 1;
             // 
             // lbLocalPath
@@ -467,7 +489,7 @@ namespace SuperPutty
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.buttonCancel;
-            this.ClientSize = new System.Drawing.Size(470, 431);
+            this.ClientSize = new System.Drawing.Size(515, 431);
             this.Controls.Add(this.groupBoxFileTransferOptions);
             this.Controls.Add(this.buttonClearSPSLFile);
             this.Controls.Add(this.label7);
@@ -531,6 +553,7 @@ namespace SuperPutty
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.TextBox textBoxExtraArgs;
         private System.Windows.Forms.RadioButton radioButtonMintty;
+        private System.Windows.Forms.RadioButton radioButtonVNC;
         private System.Windows.Forms.Button buttonImageSelect;
         private System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.Label label7;

--- a/SuperPutty/dlgEditSession.cs
+++ b/SuperPutty/dlgEditSession.cs
@@ -197,8 +197,6 @@ namespace SuperPutty
             this.textBoxPort.Enabled = !isLocalShell;
             this.textBoxExtraArgs.Enabled = !isLocalShell;
             this.textBoxUsername.Enabled = !isLocalShell;
-            this.textBoxHostname.Enabled = !isLocalShell;
-            this.comboBoxPuttyProfile.Enabled = !isLocalShell;
 
             if (isLocalShell)
             {

--- a/SuperPutty/dlgEditSession.cs
+++ b/SuperPutty/dlgEditSession.cs
@@ -149,6 +149,7 @@ namespace SuperPutty
         private void buttonSave_Click(object sender, EventArgs e)
         {
 
+            int val = 0;
             if (!String.IsNullOrEmpty(CommandLineOptions.getcommand(textBoxExtraArgs.Text, "-pw")))
             {
                 if (MessageBox.Show("SuperPutty save the password in Sessions.xml file in plain text.\nUse a password in 'Extra PuTTY Arguments' is very insecure.\nFor a secure connection use SSH authentication with Pageant. \nSelect yes, if you want save the password", "Are you sure that you want to save the password?",
@@ -162,7 +163,7 @@ namespace SuperPutty
             Session.PuttySession = comboBoxPuttyProfile.Text.Trim();
             Session.Host         = textBoxHostname.Text.Trim();
             Session.ExtraArgs    = textBoxExtraArgs.Text.Trim();
-            if (!Int32.TryParse(this.textBoxPort.Text, out int val))
+            if (!Int32.TryParse(this.textBoxPort.Text, out val))
                 Session.Port     = 0;
             else
                 Session.Port     = int.Parse(textBoxPort.Text.Trim());

--- a/SuperPutty/dlgFindPutty.Designer.cs
+++ b/SuperPutty/dlgFindPutty.Designer.cs
@@ -84,6 +84,9 @@
             this.buttonBrowseFilezilla = new System.Windows.Forms.Button();
             this.label22 = new System.Windows.Forms.Label();
             this.textBoxFilezillaLocation = new System.Windows.Forms.TextBox();
+            this.textBoxVNCLocation = new System.Windows.Forms.TextBox();
+            this.label24 = new System.Windows.Forms.Label();
+            this.btnBrowseVNC = new System.Windows.Forms.Button();
             this.buttonBrowseWinSCP = new System.Windows.Forms.Button();
             this.label21 = new System.Windows.Forms.Label();
             this.textBoxWinSCPLocation = new System.Windows.Forms.TextBox();
@@ -240,7 +243,7 @@
             // 
             this.textBoxSettingsFolder.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxSettingsFolder.Location = new System.Drawing.Point(172, 243);
+            this.textBoxSettingsFolder.Location = new System.Drawing.Point(172, 270);
             this.textBoxSettingsFolder.Name = "textBoxSettingsFolder";
             this.textBoxSettingsFolder.Size = new System.Drawing.Size(357, 22);
             this.textBoxSettingsFolder.TabIndex = 4;
@@ -249,7 +252,7 @@
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(4, 246);
+            this.label3.Location = new System.Drawing.Point(4, 273);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(143, 15);
             this.label3.TabIndex = 9;
@@ -259,7 +262,7 @@
             // buttonBrowseLayoutsFolder
             // 
             this.buttonBrowseLayoutsFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonBrowseLayoutsFolder.Location = new System.Drawing.Point(535, 243);
+            this.buttonBrowseLayoutsFolder.Location = new System.Drawing.Point(535, 270);
             this.buttonBrowseLayoutsFolder.Name = "buttonBrowseLayoutsFolder";
             this.buttonBrowseLayoutsFolder.Size = new System.Drawing.Size(75, 23);
             this.buttonBrowseLayoutsFolder.TabIndex = 5;
@@ -271,7 +274,7 @@
             // 
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(4, 274);
+            this.label4.Location = new System.Drawing.Point(4, 301);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(84, 15);
             this.label4.TabIndex = 12;
@@ -284,7 +287,7 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.comboBoxLayouts.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBoxLayouts.FormattingEnabled = true;
-            this.comboBoxLayouts.Location = new System.Drawing.Point(172, 270);
+            this.comboBoxLayouts.Location = new System.Drawing.Point(172, 297);
             this.comboBoxLayouts.Name = "comboBoxLayouts";
             this.comboBoxLayouts.Size = new System.Drawing.Size(357, 21);
             this.comboBoxLayouts.TabIndex = 6;
@@ -640,6 +643,9 @@
             this.tabPageGeneral.Controls.Add(this.buttonBrowseFilezilla);
             this.tabPageGeneral.Controls.Add(this.label22);
             this.tabPageGeneral.Controls.Add(this.textBoxFilezillaLocation);
+            this.tabPageGeneral.Controls.Add(this.btnBrowseVNC);
+            this.tabPageGeneral.Controls.Add(this.label24);
+            this.tabPageGeneral.Controls.Add(this.textBoxVNCLocation);
             this.tabPageGeneral.Controls.Add(this.buttonBrowseWinSCP);
             this.tabPageGeneral.Controls.Add(this.label21);
             this.tabPageGeneral.Controls.Add(this.textBoxWinSCPLocation);
@@ -670,7 +676,7 @@
             // 
             this.label23.AutoSize = true;
             this.label23.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label23.Location = new System.Drawing.Point(4, 300);
+            this.label23.Location = new System.Drawing.Point(4, 327);
             this.label23.Name = "label23";
             this.label23.Size = new System.Drawing.Size(145, 15);
             this.label23.TabIndex = 41;
@@ -680,7 +686,7 @@
             // 
             this.textBoxPuttyDefaultParameters.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxPuttyDefaultParameters.Location = new System.Drawing.Point(172, 297);
+            this.textBoxPuttyDefaultParameters.Location = new System.Drawing.Point(172, 324);
             this.textBoxPuttyDefaultParameters.Name = "textBoxPuttyDefaultParameters";
             this.textBoxPuttyDefaultParameters.Size = new System.Drawing.Size(357, 22);
             this.textBoxPuttyDefaultParameters.TabIndex = 40;
@@ -715,6 +721,36 @@
             this.textBoxFilezillaLocation.Size = new System.Drawing.Size(357, 22);
             this.textBoxFilezillaLocation.TabIndex = 37;
             this.textBoxFilezillaLocation.DoubleClick += new System.EventHandler(this.textBoxFilezillaLocation_DoubleClick);
+            // 
+            // textBoxVNCLocation
+            // 
+            this.textBoxVNCLocation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBoxVNCLocation.Location = new System.Drawing.Point(172, 243);
+            this.textBoxVNCLocation.Name = "textBoxVNCLocation";
+            this.textBoxVNCLocation.Size = new System.Drawing.Size(357, 22);
+            this.textBoxVNCLocation.TabIndex = 31;
+            // 
+            // label7
+            // 
+            this.label24.AutoSize = true;
+            this.label24.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label24.Location = new System.Drawing.Point(4, 246);
+            this.label24.Name = "label24";
+            this.label24.Size = new System.Drawing.Size(111, 15);
+            this.label24.TabIndex = 33;
+            this.label24.Text = "TightVNC Viewer Location";
+            // 
+            // btnBrowseVNC
+            // 
+            this.btnBrowseVNC.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnBrowseVNC.Location = new System.Drawing.Point(535, 243);
+            this.btnBrowseVNC.Name = "btnBrowseVNC";
+            this.btnBrowseVNC.Size = new System.Drawing.Size(75, 23);
+            this.btnBrowseVNC.TabIndex = 32;
+            this.btnBrowseVNC.Text = "Browse";
+            this.btnBrowseVNC.UseVisualStyleBackColor = true;
+            this.btnBrowseVNC.Click += new System.EventHandler(this.btnBrowseVNC_Click);
             // 
             // buttonBrowseWinSCP
             // 
@@ -1246,6 +1282,9 @@
         private System.Windows.Forms.TextBox textBoxMinttyLocation;
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.Button btnBrowseMintty;
+        private System.Windows.Forms.TextBox textBoxVNCLocation;
+        private System.Windows.Forms.Label label24;
+        private System.Windows.Forms.Button btnBrowseVNC;
         private System.Windows.Forms.Label label8;
         private System.Windows.Forms.ComboBox comboBoxTabText;
         private System.Windows.Forms.Label label9;

--- a/SuperPutty/dlgFindPutty.cs
+++ b/SuperPutty/dlgFindPutty.cs
@@ -53,6 +53,7 @@ namespace SuperPutty
             bool firstExecution = String.IsNullOrEmpty(puttyExe);
             textBoxFilezillaLocation.Text = getPathExe(@"\FileZilla FTP Client\filezilla.exe", SuperPuTTY.Settings.FileZillaExe, firstExecution);
             textBoxWinSCPLocation.Text = getPathExe(@"\WinSCP\WinSCP.exe", SuperPuTTY.Settings.WinSCPExe, firstExecution);
+            textBoxVNCLocation.Text = getPathExe(@"\TightVNC\tvnviewer.exe", SuperPuTTY.Settings.VNCExe, firstExecution);
 
             // check for location of putty/pscp
             if (!String.IsNullOrEmpty(puttyExe) && File.Exists(puttyExe))
@@ -100,6 +101,10 @@ namespace SuperPutty
                 if (File.Exists(@"C:\cygwin\bin\mintty.exe"))
                 {
                     this.textBoxMinttyLocation.Text = @"C:\cygwin\bin\mintty.exe";
+                }
+                if (File.Exists(@"C:\cygwin64\bin\mintty.exe"))
+                {
+                    this.textBoxMinttyLocation.Text = @"C:\cygwin64\bin\mintty.exe";
                 }
             }
             else
@@ -292,6 +297,11 @@ namespace SuperPutty
                 SuperPuTTY.Settings.PscpExe = textBoxPscpLocation.Text;
             }
 
+            if (String.IsNullOrEmpty(textBoxVNCLocation.Text) || File.Exists(textBoxVNCLocation.Text))
+            {
+                SuperPuTTY.Settings.VNCExe = textBoxVNCLocation.Text;
+            }
+
             string settingsDir = textBoxSettingsFolder.Text;
             if (String.IsNullOrEmpty(settingsDir) || !Directory.Exists(settingsDir))
             {
@@ -425,6 +435,11 @@ namespace SuperPutty
             dialogBrowseExe("WinSCP|WinSCP.exe", "WinSCP.exe", textBoxWinSCPLocation);
         }
 
+        private void btnBrowseVNC_Click(object sender, EventArgs e)
+        {
+            dialogBrowseExe("tvnviewer|tvnviewer.exe", "tvnviewer.exe", textBoxVNCLocation);
+        }
+
         private void dialogBrowseExe(String filter, string filename, TextBox textbox)
         {
             openFileDialog1.Filter = filter;
@@ -452,6 +467,12 @@ namespace SuperPutty
         private void textBoxWinSCPLocation_DoubleClick(object sender, EventArgs e)
         {
             textBoxWinSCPLocation.Text = getPathExe(@"\WinSCP\WinSCP.exe", SuperPuTTY.Settings.WinSCPExe, true);
+        }
+
+        //Search automaticaly the path of WinSCP when doubleClick when it is empty
+        private void textBoxVNCLocation_DoubleClick(object sender, EventArgs e)
+        {
+            textBoxVNCLocation.Text = getPathExe(@"\TightVNC\tvnviewer.exe", SuperPuTTY.Settings.VNCExe, true);
         }
 
 

--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -986,8 +986,9 @@ namespace SuperPutty
 
             if (!String.IsNullOrEmpty(host))
             {
-                HostConnectionString connStr = new HostConnectionString(host);
                 bool isScp = "SCP" == protoString;
+                bool isVnc = "VNC" == protoString;
+                HostConnectionString connStr = new HostConnectionString(host, isVnc);
                 ConnectionProtocol proto = isScp
                     ? ConnectionProtocol.SSH
                     : connStr.Protocol.GetValueOrDefault((ConnectionProtocol)Enum.Parse(typeof(ConnectionProtocol), protoString));
@@ -1670,7 +1671,10 @@ namespace SuperPutty
                         GitRelease latest = (GitRelease)js.ReadObject(ms);
                         ms.Close();
 
-                        if (!latest.version.Trim().Contains(SuperPuTTY.Version))
+                        Version latest_version = new Version(latest.version.Trim());
+                        Version SuperPuTTY_version = new Version(SuperPuTTY.Version);
+
+                        if (latest_version.CompareTo(SuperPuTTY_version) > 0)
                         {
                             Log.Info("New Application version found! " + latest.version);
 
@@ -1700,6 +1704,10 @@ namespace SuperPutty
                 });
             }
             catch (System.Net.WebException ex)
+            {
+                Log.Warn("An Exception occurred while trying to check for program updates: " + ex.ToString());
+            }
+            catch (System.FormatException ex)
             {
                 Log.Warn("An Exception occurred while trying to check for program updates: " + ex.ToString());
             }


### PR DESCRIPTION
The administrators often need to view the desktop of multiple systems simultaneously. One of the most popular mechanisms is VNC.
There is no available tool that supports having multiple VNC windows docked side-by-side.
Since SuperPuTTY handles this feature already, it is a good feature add for SuperPuTTY.

This change adds a new option "VNC" in the protocol list.

1. You can use the command line option "-vnc"
2. You can create a new session from toolbar by choosing VNC as the protocol.
3. You can create and save a new session with VNC as the protocol.

VNC viewer functionality is provided via tightvnc viewer.