### PR TITLE
Serial port 728

### DIFF
--- a/SuperPutty/Data/SessionData.cs
+++ b/SuperPutty/Data/SessionData.cs
@@ -227,6 +227,92 @@ namespace SuperPutty.Data
             }
         }
 
+        #region Serial Port Settings
+        private string _SerialLine;
+        [XmlAttribute]
+        [DisplayName("Serial Line")]
+        [Description("Serial port to use for the connection. Ex: COM3")]
+        public string SerialLine
+        {
+            get { return _SerialLine; }
+            set
+            {
+                UpdateField(ref _SerialLine, value, "SerialLine");
+            }
+        }
+
+
+        private string _SerialSpeed;
+        [XmlAttribute]
+        [DisplayName("Serial Port Speed")]
+        [Description("Baud rate of the serial port")]
+        public string SerialSpeed
+        {
+            get { return _SerialSpeed; }
+            set
+            {
+                UpdateField(ref _SerialSpeed, value, "SerialSpeed");
+            }
+
+        }
+
+        private string _SerialDataBits;
+        [XmlAttribute]
+        [DisplayName("Data bits")]
+        [Description("Number of data bits following the stop bit in the serial data stream")]
+        public string SerialDataBits
+        {
+            get { return _SerialDataBits; }
+            set
+            {
+                UpdateField(ref _SerialDataBits, value, "SerialDataBits");
+            }
+
+        }
+
+        private string _SerialStopBits;
+        [XmlAttribute]
+        [DisplayName("Serial Stop Bits")]
+        [Description("Period of time before the next start bit can begin transmission.")]
+        public string SerialStopBits
+        {
+            get { return _SerialStopBits; }
+            set
+            {
+                UpdateField(ref _SerialStopBits, value, "SerialStopBits");
+            }
+
+        }
+
+        private string _SerialParity;
+        [XmlAttribute]
+        [DisplayName("Serial Parity")]
+        [Description("Parity method used for error detection.")]
+        public string SerialParity
+        {
+            get { return _SerialParity; }
+            set
+            {
+                UpdateField(ref _SerialParity, value, "SerialParity");
+            }
+
+        }
+
+        private string _SerialFlowControl;
+        [XmlAttribute]
+        [DisplayName("Serial Flow Control")]
+        [Description("Software or Hardware flow control mechanism for the slow down the flow of bytes on a wire.")]
+        public string SerialFlowControl
+        {
+            get { return _SerialFlowControl; }
+            set
+            {
+                UpdateField(ref _SerialFlowControl, value, "SerialFlowControl");
+            }
+
+        }
+        #endregion
+
         private DockState m_LastDockstate = DockState.Document;
         [XmlIgnore]
         [Browsable(false)]
@@ -282,7 +368,7 @@ namespace SuperPutty.Data
         /// <param name="port">The port on the remote host</param>
         /// <param name="protocol">The protocol to use when connecting to the remote host</param>
         /// <param name="sessionConfig">the name of the saved configuration settings from putty to use</param>
-        public SessionData(string sessionName, string hostName, int port, ConnectionProtocol protocol, string sessionConfig)
+        public SessionData(string sessionName, string hostName, int port, ConnectionProtocol protocol, string sessionConfig) : this()
         {
             SessionName = sessionName;
             Host = hostName;
@@ -290,11 +376,16 @@ namespace SuperPutty.Data
             Proto = protocol;
             PuttySession = sessionConfig;
         }
-        
+
         /// <summary>Default constructor, instantiate a new <seealso cref="SessionData"/> object</summary>
         public SessionData()
         {
-
+            _SerialLine = "";
+            _SerialSpeed = "";
+            _SerialDataBits = "";
+            _SerialStopBits = "";
+            _SerialParity = "";
+            _SerialFlowControl = "";
         }
 
         private void UpdateField<T>(ref T Field, T NewValue, string PropertyName)

--- a/SuperPutty/SuperPutty.csproj
+++ b/SuperPutty/SuperPutty.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Utils\GlobalWindowEvents.cs" />
     <Compile Include="Utils\HostConnectionString.cs" />
     <Compile Include="Utils\MinttyStartInfo.cs" />
+    <Compile Include="Utils\SerialConnectionOptions.cs" />
     <Compile Include="Utils\VNCStartInfo.cs" />
     <Compile Include="Utils\NativeMethods.cs" />
     <Compile Include="Utils\PortableSettingsProvider.cs" />

--- a/SuperPutty/Utils/PuttyStartInfo.cs
+++ b/SuperPutty/Utils/PuttyStartInfo.cs
@@ -53,6 +53,11 @@ namespace SuperPutty.Utils
                 this.Args = vnc.Args;
                 this.WorkingDir = vnc.StartingDir;
             }
+            else if(session.Proto == ConnectionProtocol.Serial)
+            {
+                this.Args = MakeArgsSerial(session);
+                argsToLog = MakeArgsSerial(session);
+            }
             else
             {
                 this.Args = MakeArgs(session, true);
@@ -87,6 +92,36 @@ namespace SuperPutty.Utils
 
             return args;
         }
+
+
+        static string MakeArgsSerial(SessionData session)
+        {
+            string args = "-" + session.Proto.ToString().ToLower() + " ";
+
+            string sercfg = "-sercfg " + session.SerialSpeed.Trim();
+            if (!String.IsNullOrEmpty(session.SerialDataBits))
+                sercfg += "," + SerialConnectionOptions.DataBitsToPuttyCode(session.SerialDataBits);
+            if (!String.IsNullOrEmpty(session.SerialParity))
+                sercfg += "," + SerialConnectionOptions.ParityStrToPuttyCode(session.SerialParity);
+            if (!String.IsNullOrEmpty(session.SerialStopBits))
+                sercfg += "," + SerialConnectionOptions.StopBitsToPuttyCode(session.SerialStopBits);
+            if (!String.IsNullOrEmpty(session.SerialFlowControl))
+                sercfg += "," + SerialConnectionOptions.FlowControlToPuttyCode(session.SerialFlowControl);
+            args += sercfg;
+            args += " ";
+
+            args += !String.IsNullOrEmpty(session.PuttySession) ? "-load \"" + session.PuttySession + "\" " : "";
+            args += !String.IsNullOrEmpty(SuperPuTTY.Settings.PuttyDefaultParameters) ? SuperPuTTY.Settings.PuttyDefaultParameters + " " : "";
+
+            //If extra args contains the password, delete it (it's in session.password)
+            string extraArgs = CommandLineOptions.replacePassword(session.ExtraArgs, "");
+            args += !String.IsNullOrEmpty(extraArgs) ? extraArgs + " " : "";
+
+            args += session.SerialLine;
+
+            return args;
+        }
+
 
         static string TryParseEnvVars(string args)
         {

--- a/SuperPutty/Utils/SerialConnectionOptions.cs
+++ b/SuperPutty/Utils/SerialConnectionOptions.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO.Ports;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace SuperPutty.Utils
 {
@@ -21,5 +24,75 @@ namespace SuperPutty.Utils
         public readonly static string DefaultStopBits = StopBits[0];
         public readonly static string[] FlowControl = { "None", "XON/XOFF", "RTS/CTS", "DSR/DTR" };
         public readonly static string DefaultFlowControl = FlowControl[0];
+
+        internal static void InitializeSerialPortCombo(Component uiComponent, string value="")
+        {
+            initializeSerialCombo(uiComponent, SerialPort.GetPortNames(), "", value);
+        }
+
+        internal static void InitializeSerialSpeedCombo(Component uiComponent, string value = "")
+        {
+            initializeSerialCombo(uiComponent, BaudRates, DefaultBaudRate, value);
+        }
+
+        internal static void InitializeSerialStopBitsCombo(Component uiComponent, string value = "")
+        {
+            initializeSerialCombo(uiComponent, StopBits, DefaultStopBits, value);
+        }
+
+        internal static void InitializeSerialDataBitsCombo(Component uiComponent, string value = "")
+        {
+            initializeSerialCombo(uiComponent, DataBits, DefaultDataBits, value);
+        }
+
+        internal static void InitializeSerialParityCombo(Component uiComponent, string value = "")
+        {
+            initializeSerialCombo(uiComponent, Parity, DefaultParity, value);
+        }
+
+        internal static void InitializeSerialFlowCtrlCombo(Component uiComponent, string value = "")
+        {
+            initializeSerialCombo(uiComponent, FlowControl, DefaultFlowControl, value);
+        }
+
+        public static void initializeSerialCombo(Component uiComponent, string[] listValues, string defaultSelection, string value)
+        {
+            ComboBox thisComboBox = getComboBoxObject(uiComponent);
+            thisComboBox.Items.Clear();
+            thisComboBox.Items.AddRange(listValues);
+            if ((value != null) && (value.Length > 0))
+            {
+                if (!thisComboBox.Items.Contains(value))
+                    thisComboBox.Items.Add(value);
+                thisComboBox.SelectedItem = value;
+            }
+            else if (thisComboBox.Items.Count > 0)
+            {
+                if (defaultSelection.Length > 0)
+                {
+                    thisComboBox.SelectedItem = defaultSelection;
+                }
+                else { thisComboBox.SelectedIndex = 0; }
+            }
+        }
+
+
+        /// <summary>
+        /// The utilities in this class can be used to initialize Tool Strip combo boxes, or
+        /// normal combo boxes. This method will check to see if the component is a Combo
+        /// Box or Tool Strip Combo. If its a tool strip combo box, it will return the embedded
+        /// combo box object.
+        /// </summary>
+        /// <param name="parentComponent"></param>
+        /// <returns></returns>
+        private static ComboBox getComboBoxObject(Component parentComponent)
+        {
+            if (parentComponent is ComboBox)
+                return (ComboBox)parentComponent;
+            else if (parentComponent is ToolStripComboBox)
+                return ((ToolStripComboBox)parentComponent).ComboBox;
+            else
+                return null;
+        }
     }
 }

--- a/SuperPutty/Utils/SerialConnectionOptions.cs
+++ b/SuperPutty/Utils/SerialConnectionOptions.cs
@@ -55,7 +55,20 @@ namespace SuperPutty.Utils
             initializeSerialCombo(uiComponent, FlowControl, DefaultFlowControl, value);
         }
 
-        public static void initializeSerialCombo(Component uiComponent, string[] listValues, string defaultSelection, string value)
+        /// <summary>
+        /// Local utility method for setting up combo boxes in the GUI.
+        /// 
+        /// Will set the combo box items to the listValues.
+        /// If 'value' is a non-empty string, will make sure it is an option in the combo box. 
+        ///     If its not, will add it to the list of options.
+        /// If the 'value' is in the listValues, will set the current selection to value. 
+        /// If 'value' is an empty string, will set the current selection to defaultSelection.
+        /// </summary>
+        /// <param name="uiComponent">ComboBox or ToolStripComboBox object to configure</param>
+        /// <param name="listValues">List of options that are available in the combo box</param>
+        /// <param name="defaultSelection">If 'value' is not specified, the combobox will be set to this</param>
+        /// <param name="value">The ComboBox will be set to this value as the selected item.</param>
+        private static void initializeSerialCombo(Component uiComponent, string[] listValues, string defaultSelection, string value)
         {
             ComboBox thisComboBox = getComboBoxObject(uiComponent);
             thisComboBox.Items.Clear();
@@ -94,5 +107,84 @@ namespace SuperPutty.Utils
             else
                 return null;
         }
+
+
+        /// <summary>
+        /// The -SERCFG option that is passed into putty uses different codes than the human-readable
+        /// options specified in this class. This method will convert them to what putty is expecting
+        /// 
+        /// From the putty documentation, options are:
+        ///         A single lower-case letter specifies the parity: ‘n’ for none, ‘o’ for odd, 
+        ///         ‘e’ for even, ‘m’ for mark and ‘s’ for space.
+        /// </summary>
+        /// <param name="parity">Human-readable parity string</param>
+        /// <returns></returns>
+        public static string ParityStrToPuttyCode(string parity)
+        {
+            return parity.ToLower().Substring(0, 1);
+        }
+
+        /// <summary>
+        /// The -SERCFG option that is passed into putty uses different codes than the human-readable
+        /// options specified in this class. This method will convert them to what putty is expecting
+        /// 
+        /// From the putty documentation, options are:
+        ///         A single upper-case letter specifies the flow control: ‘N’ for none, 
+        ///         ‘X’ for XON/XOFF, ‘R’ for RTS/CTS and ‘D’ for DSR/DTR.
+        /// </summary>
+        /// <param name="flow">Flow Control String</param>
+        /// <returns></returns>
+        public static string FlowControlToPuttyCode(string flow)
+        {
+            return flow.ToUpper().Substring(0, 1);
+        }
+
+        /// <summary>
+        /// The -SERCFG option that is passed into putty uses different codes than the human-readable
+        /// options specified in this class. This method will convert them to what putty is expecting
+        /// 
+        /// From the putty documentation, options are:
+        ///         ‘1’, ‘1.5’ or ‘2’ sets the number of stop bits.
+        /// </summary>
+        /// <param name="stopBits"></param>
+        /// <returns></returns>
+        public static string StopBitsToPuttyCode(string stopBits)
+        {
+            switch(stopBits.ToLower())
+            {
+                case "1 bit":
+                    return "1";
+                case "1.5 bit":
+                    return "1.5";
+                case "2 bit":
+                    return "2";
+                default:
+                    return "1";
+            }
+
+        }
+
+
+        /// <summary>
+        /// The -SERCFG option that is passed into putty uses different codes than the human-readable
+        /// options specified in this class. This method will convert them to what putty is expecting
+        /// 
+        /// From the putty documentation, options are:
+        ///         Any single digit from 5 to 9 sets the number of data bits.
+        /// </summary>
+        /// <param name="flow">Flow Control String</param>
+        /// <returns></returns>
+        public static string DataBitsToPuttyCode(string dataBits)
+        {
+            string retString = "8";
+            int result = -1;
+            if (Int32.TryParse(dataBits.Substring(0, 1),out result))
+            {
+                retString = result.ToString();
+            }
+            return retString;
+        }
+
+        
     }
 }

--- a/SuperPutty/Utils/SerialConnectionOptions.cs
+++ b/SuperPutty/Utils/SerialConnectionOptions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SuperPutty.Utils
+{
+    public static class SerialConnectionOptions
+    {
+        public readonly static string[] BaudRates =
+        {
+            "1200", "2400", "4800", "9600", "19200", "38400", "57600", "115200"
+        };
+        public readonly static string DefaultBaudRate = BaudRates[3];
+        public readonly static string[] DataBits = { "7 bit", "8 bit" };
+        public readonly static string DefaultDataBits = DataBits[1];
+        public readonly static string[] Parity = { "None", "Odd", "Even", "Mark", "Space" };
+        public readonly static string DefaultParity = Parity[0];
+        public readonly static string[] StopBits = { "1 bit", "1.5 bit", "2 bit" };
+        public readonly static string DefaultStopBits = StopBits[0];
+        public readonly static string[] FlowControl = { "None", "XON/XOFF", "RTS/CTS", "DSR/DTR" };
+        public readonly static string DefaultFlowControl = FlowControl[0];
+    }
+}

--- a/SuperPutty/dlgEditSession.Designer.cs
+++ b/SuperPutty/dlgEditSession.Designer.cs
@@ -30,11 +30,11 @@ namespace SuperPutty
         {
             this.components = new System.ComponentModel.Container();
             this.textBoxSessionName = new System.Windows.Forms.TextBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
+            this.labelSessionname = new System.Windows.Forms.Label();
+            this.labelHostName = new System.Windows.Forms.Label();
             this.textBoxHostname = new System.Windows.Forms.TextBox();
             this.textBoxPort = new System.Windows.Forms.TextBox();
-            this.label3 = new System.Windows.Forms.Label();
+            this.labelPort = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.radioButtonVNC = new System.Windows.Forms.RadioButton();
             this.radioButtonMintty = new System.Windows.Forms.RadioButton();
@@ -51,6 +51,20 @@ namespace SuperPutty
             this.label4 = new System.Windows.Forms.Label();
             this.comboBoxPuttyProfile = new System.Windows.Forms.ComboBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.panelSerialConnSettings = new System.Windows.Forms.Panel();
+            this.labelSerialLine = new System.Windows.Forms.Label();
+            this.comboBoxSerialLine = new System.Windows.Forms.ComboBox();
+            this.labelSerialSpeed = new System.Windows.Forms.Label();
+            this.comboBoxSerialSpeed = new System.Windows.Forms.ComboBox();
+            this.labelSerialDataBits = new System.Windows.Forms.Label();
+            this.comboBoxSerialDataBits = new System.Windows.Forms.ComboBox();
+            this.labelSerialStopBits = new System.Windows.Forms.Label();
+            this.comboBoxSerialStopBits = new System.Windows.Forms.ComboBox();
+            this.labelSerialParity = new System.Windows.Forms.Label();
+            this.comboBoxSerialParity = new System.Windows.Forms.ComboBox();
+            this.labelSerialFlowControl = new System.Windows.Forms.Label();
+            this.comboBoxSerialFlowCtrl = new System.Windows.Forms.ComboBox();
+            this.panelIpConnection = new System.Windows.Forms.Panel();
             this.label5 = new System.Windows.Forms.Label();
             this.textBoxUsername = new System.Windows.Forms.TextBox();
             this.errorProvider = new System.Windows.Forms.ErrorProvider(this.components);
@@ -70,6 +84,8 @@ namespace SuperPutty
             this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
+            this.panelSerialConnSettings.SuspendLayout();
+            this.panelIpConnection.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).BeginInit();
             this.groupBoxFileTransferOptions.SuspendLayout();
             this.SuspendLayout();
@@ -85,40 +101,40 @@ namespace SuperPutty
             this.textBoxSessionName.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxSessionName_Validating);
             this.textBoxSessionName.Validated += new System.EventHandler(this.textBoxSessionName_Validated);
             // 
-            // label1
+            // labelSessionname
             // 
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(6, 16);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(81, 15);
-            this.label1.TabIndex = 1;
-            this.label1.Text = "Session Name";
+            this.labelSessionname.AutoSize = true;
+            this.labelSessionname.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelSessionname.Location = new System.Drawing.Point(6, 16);
+            this.labelSessionname.Name = "labelSessionname";
+            this.labelSessionname.Size = new System.Drawing.Size(81, 15);
+            this.labelSessionname.TabIndex = 1;
+            this.labelSessionname.Text = "Session Name";
             // 
-            // label2
+            // labelHostName
             // 
-            this.label2.AutoSize = true;
-            this.label2.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(6, 56);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(147, 15);
-            this.label2.TabIndex = 2;
-            this.label2.Text = "Host Name (or IP Address)";
+            this.labelHostName.AutoSize = true;
+            this.labelHostName.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelHostName.Location = new System.Drawing.Point(6, 3);
+            this.labelHostName.Name = "labelHostName";
+            this.labelHostName.Size = new System.Drawing.Size(147, 15);
+            this.labelHostName.TabIndex = 2;
+            this.labelHostName.Text = "Host Name (or IP Address)";
             // 
             // textBoxHostname
             // 
             this.textBoxHostname.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxHostname.Location = new System.Drawing.Point(6, 74);
+            this.textBoxHostname.Location = new System.Drawing.Point(6, 24);
             this.textBoxHostname.Name = "textBoxHostname";
-            this.textBoxHostname.Size = new System.Drawing.Size(361, 20);
+            this.textBoxHostname.Size = new System.Drawing.Size(352, 20);
             this.textBoxHostname.TabIndex = 1;
             this.textBoxHostname.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxHostname_Validating);
             // 
             // textBoxPort
             // 
             this.textBoxPort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxPort.Location = new System.Drawing.Point(390, 74);
+            this.textBoxPort.Location = new System.Drawing.Point(381, 24);
             this.textBoxPort.Name = "textBoxPort";
             this.textBoxPort.Size = new System.Drawing.Size(80, 20);
             this.textBoxPort.TabIndex = 2;
@@ -126,16 +142,16 @@ namespace SuperPutty
             this.textBoxPort.Validating += new System.ComponentModel.CancelEventHandler(this.textBoxPort_Validating);
             this.textBoxPort.Validated += new System.EventHandler(this.textBoxPort_Validated);
             // 
-            // label3
+            // labelPort
             // 
-            this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label3.AutoSize = true;
-            this.label3.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(387, 56);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(53, 15);
-            this.label3.TabIndex = 5;
-            this.label3.Text = "TCP Port";
+            this.labelPort.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelPort.AutoSize = true;
+            this.labelPort.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelPort.Location = new System.Drawing.Point(378, 3);
+            this.labelPort.Name = "labelPort";
+            this.labelPort.Size = new System.Drawing.Size(53, 15);
+            this.labelPort.TabIndex = 5;
+            this.labelPort.Text = "TCP Port";
             // 
             // groupBox1
             // 
@@ -207,6 +223,7 @@ namespace SuperPutty
             this.radioButtonSerial.Tag = SuperPutty.Data.ConnectionProtocol.Serial;
             this.radioButtonSerial.Text = "Serial";
             this.radioButtonSerial.UseVisualStyleBackColor = true;
+            this.radioButtonSerial.CheckedChanged += new System.EventHandler(this.radioButtonSerial_CheckedChanged);
             // 
             // radioButtonSSH
             // 
@@ -332,17 +349,162 @@ namespace SuperPutty
             // 
             this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox2.Controls.Add(this.label1);
+            this.groupBox2.Controls.Add(this.panelSerialConnSettings);
+            this.groupBox2.Controls.Add(this.panelIpConnection);
+            this.groupBox2.Controls.Add(this.labelSessionname);
             this.groupBox2.Controls.Add(this.textBoxSessionName);
-            this.groupBox2.Controls.Add(this.label2);
-            this.groupBox2.Controls.Add(this.textBoxHostname);
-            this.groupBox2.Controls.Add(this.label3);
-            this.groupBox2.Controls.Add(this.textBoxPort);
             this.groupBox2.Location = new System.Drawing.Point(14, 5);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(485, 109);
             this.groupBox2.TabIndex = 11;
             this.groupBox2.TabStop = false;
+            // 
+            // panelSerialConnSettings
+            // 
+            this.panelSerialConnSettings.Controls.Add(this.labelSerialLine);
+            this.panelSerialConnSettings.Controls.Add(this.comboBoxSerialLine);
+            this.panelSerialConnSettings.Controls.Add(this.labelSerialSpeed);
+            this.panelSerialConnSettings.Controls.Add(this.comboBoxSerialSpeed);
+            this.panelSerialConnSettings.Controls.Add(this.labelSerialDataBits);
+            this.panelSerialConnSettings.Controls.Add(this.comboBoxSerialDataBits);
+            this.panelSerialConnSettings.Controls.Add(this.labelSerialStopBits);
+            this.panelSerialConnSettings.Controls.Add(this.comboBoxSerialStopBits);
+            this.panelSerialConnSettings.Controls.Add(this.labelSerialParity);
+            this.panelSerialConnSettings.Controls.Add(this.comboBoxSerialParity);
+            this.panelSerialConnSettings.Controls.Add(this.labelSerialFlowControl);
+            this.panelSerialConnSettings.Controls.Add(this.comboBoxSerialFlowCtrl);
+            this.panelSerialConnSettings.Location = new System.Drawing.Point(3, 56);
+            this.panelSerialConnSettings.Name = "panelSerialConnSettings";
+            this.panelSerialConnSettings.Size = new System.Drawing.Size(479, 53);
+            this.panelSerialConnSettings.TabIndex = 7;
+            // 
+            // labelSerialLine
+            // 
+            this.labelSerialLine.AutoSize = true;
+            this.labelSerialLine.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelSerialLine.Location = new System.Drawing.Point(6, 3);
+            this.labelSerialLine.Name = "labelSerialLine";
+            this.labelSerialLine.Size = new System.Drawing.Size(60, 15);
+            this.labelSerialLine.TabIndex = 2;
+            this.labelSerialLine.Text = "Serial Line";
+            // 
+            // comboBoxSerialLine
+            // 
+            this.comboBoxSerialLine.FormattingEnabled = true;
+            this.comboBoxSerialLine.Location = new System.Drawing.Point(6, 24);
+            this.comboBoxSerialLine.Name = "comboBoxSerialLine";
+            this.comboBoxSerialLine.Size = new System.Drawing.Size(90, 21);
+            this.comboBoxSerialLine.TabIndex = 6;
+            // 
+            // labelSerialSpeed
+            // 
+            this.labelSerialSpeed.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelSerialSpeed.AutoSize = true;
+            this.labelSerialSpeed.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelSerialSpeed.Location = new System.Drawing.Point(100, 6);
+            this.labelSerialSpeed.Name = "labelSerialSpeed";
+            this.labelSerialSpeed.Size = new System.Drawing.Size(39, 15);
+            this.labelSerialSpeed.TabIndex = 5;
+            this.labelSerialSpeed.Text = "Speed";
+            // 
+            // comboBoxSerialSpeed
+            // 
+            this.comboBoxSerialSpeed.FormattingEnabled = true;
+            this.comboBoxSerialSpeed.Location = new System.Drawing.Point(100, 24);
+            this.comboBoxSerialSpeed.Name = "comboBoxSerialSpeed";
+            this.comboBoxSerialSpeed.Size = new System.Drawing.Size(65, 21);
+            this.comboBoxSerialSpeed.TabIndex = 17;
+            // 
+            // labelSerialDataBits
+            // 
+            this.labelSerialDataBits.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelSerialDataBits.AutoSize = true;
+            this.labelSerialDataBits.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelSerialDataBits.Location = new System.Drawing.Point(170, 6);
+            this.labelSerialDataBits.Name = "labelSerialDataBits";
+            this.labelSerialDataBits.Size = new System.Drawing.Size(53, 15);
+            this.labelSerialDataBits.TabIndex = 7;
+            this.labelSerialDataBits.Text = "Data Bits";
+            // 
+            // comboBoxSerialDataBits
+            // 
+            this.comboBoxSerialDataBits.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxSerialDataBits.FormattingEnabled = true;
+            this.comboBoxSerialDataBits.Location = new System.Drawing.Point(170, 24);
+            this.comboBoxSerialDataBits.Name = "comboBoxSerialDataBits";
+            this.comboBoxSerialDataBits.Size = new System.Drawing.Size(65, 21);
+            this.comboBoxSerialDataBits.TabIndex = 15;
+            // 
+            // labelSerialStopBits
+            // 
+            this.labelSerialStopBits.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelSerialStopBits.AutoSize = true;
+            this.labelSerialStopBits.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelSerialStopBits.Location = new System.Drawing.Point(240, 6);
+            this.labelSerialStopBits.Name = "labelSerialStopBits";
+            this.labelSerialStopBits.Size = new System.Drawing.Size(53, 15);
+            this.labelSerialStopBits.TabIndex = 8;
+            this.labelSerialStopBits.Text = "Stop Bits";
+            // 
+            // comboBoxSerialStopBits
+            // 
+            this.comboBoxSerialStopBits.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxSerialStopBits.FormattingEnabled = true;
+            this.comboBoxSerialStopBits.Location = new System.Drawing.Point(240, 24);
+            this.comboBoxSerialStopBits.Name = "comboBoxSerialStopBits";
+            this.comboBoxSerialStopBits.Size = new System.Drawing.Size(65, 21);
+            this.comboBoxSerialStopBits.TabIndex = 16;
+            // 
+            // labelSerialParity
+            // 
+            this.labelSerialParity.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelSerialParity.AutoSize = true;
+            this.labelSerialParity.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelSerialParity.Location = new System.Drawing.Point(310, 6);
+            this.labelSerialParity.Name = "labelSerialParity";
+            this.labelSerialParity.Size = new System.Drawing.Size(37, 15);
+            this.labelSerialParity.TabIndex = 9;
+            this.labelSerialParity.Text = "Parity";
+            // 
+            // comboBoxSerialParity
+            // 
+            this.comboBoxSerialParity.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxSerialParity.FormattingEnabled = true;
+            this.comboBoxSerialParity.Location = new System.Drawing.Point(310, 24);
+            this.comboBoxSerialParity.Name = "comboBoxSerialParity";
+            this.comboBoxSerialParity.Size = new System.Drawing.Size(65, 21);
+            this.comboBoxSerialParity.TabIndex = 13;
+            // 
+            // labelSerialFlowControl
+            // 
+            this.labelSerialFlowControl.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.labelSerialFlowControl.AutoSize = true;
+            this.labelSerialFlowControl.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelSerialFlowControl.Location = new System.Drawing.Point(380, 6);
+            this.labelSerialFlowControl.Name = "labelSerialFlowControl";
+            this.labelSerialFlowControl.Size = new System.Drawing.Size(75, 15);
+            this.labelSerialFlowControl.TabIndex = 10;
+            this.labelSerialFlowControl.Text = "Flow Control";
+            // 
+            // comboBoxSerialFlowCtrl
+            // 
+            this.comboBoxSerialFlowCtrl.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxSerialFlowCtrl.FormattingEnabled = true;
+            this.comboBoxSerialFlowCtrl.Location = new System.Drawing.Point(380, 24);
+            this.comboBoxSerialFlowCtrl.Name = "comboBoxSerialFlowCtrl";
+            this.comboBoxSerialFlowCtrl.Size = new System.Drawing.Size(85, 21);
+            this.comboBoxSerialFlowCtrl.TabIndex = 14;
+            // 
+            // panelIpConnection
+            // 
+            this.panelIpConnection.Controls.Add(this.labelHostName);
+            this.panelIpConnection.Controls.Add(this.textBoxHostname);
+            this.panelIpConnection.Controls.Add(this.labelPort);
+            this.panelIpConnection.Controls.Add(this.textBoxPort);
+            this.panelIpConnection.Location = new System.Drawing.Point(6, 56);
+            this.panelIpConnection.Name = "panelIpConnection";
+            this.panelIpConnection.Size = new System.Drawing.Size(476, 53);
+            this.panelIpConnection.TabIndex = 6;
             // 
             // label5
             // 
@@ -523,6 +685,10 @@ namespace SuperPutty
             this.groupBox1.PerformLayout();
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();
+            this.panelSerialConnSettings.ResumeLayout(false);
+            this.panelSerialConnSettings.PerformLayout();
+            this.panelIpConnection.ResumeLayout(false);
+            this.panelIpConnection.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.errorProvider)).EndInit();
             this.groupBoxFileTransferOptions.ResumeLayout(false);
             this.groupBoxFileTransferOptions.PerformLayout();
@@ -534,11 +700,11 @@ namespace SuperPutty
         #endregion
 
         private System.Windows.Forms.TextBox textBoxSessionName;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label labelSessionname;
+        private System.Windows.Forms.Label labelHostName;
         private System.Windows.Forms.TextBox textBoxHostname;
         private System.Windows.Forms.TextBox textBoxPort;
-        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label labelPort;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.RadioButton radioButtonSerial;
         private System.Windows.Forms.RadioButton radioButtonSSH;
@@ -572,5 +738,19 @@ namespace SuperPutty
         private System.Windows.Forms.TextBox textBoxLocalPathSesion;
         private System.Windows.Forms.Label lbLocalPath;
         private System.Windows.Forms.FolderBrowserDialog folderBrowserDialog1;
+        private System.Windows.Forms.Panel panelIpConnection;
+        private System.Windows.Forms.Panel panelSerialConnSettings;
+        private System.Windows.Forms.Label labelSerialLine;
+        private System.Windows.Forms.Label labelSerialSpeed;
+        private System.Windows.Forms.ComboBox comboBoxSerialLine;
+        private System.Windows.Forms.Label labelSerialDataBits;
+        private System.Windows.Forms.Label labelSerialStopBits;
+        private System.Windows.Forms.Label labelSerialParity;
+        private System.Windows.Forms.Label labelSerialFlowControl;
+        private System.Windows.Forms.ComboBox comboBoxSerialSpeed;
+        private System.Windows.Forms.ComboBox comboBoxSerialDataBits;
+        private System.Windows.Forms.ComboBox comboBoxSerialStopBits;
+        private System.Windows.Forms.ComboBox comboBoxSerialParity;
+        private System.Windows.Forms.ComboBox comboBoxSerialFlowCtrl;
     }
 }

--- a/SuperPutty/dlgEditSession.cs
+++ b/SuperPutty/dlgEditSession.cs
@@ -122,6 +122,29 @@ namespace SuperPutty
                 : Session.ImageKey;
             this.toolTip.SetToolTip(this.buttonImageSelect, buttonImageSelect.ImageKey);
 
+            this.comboBoxSerialLine.Items.Clear();
+            this.comboBoxSerialLine.Items.AddRange(System.IO.Ports.SerialPort.GetPortNames());
+            if(this.comboBoxSerialLine.Items.Count > 0)
+                this.comboBoxSerialLine.SelectedIndex = 0;
+            this.comboBoxSerialSpeed.Items.Clear();
+            this.comboBoxSerialSpeed.Items.AddRange(Utils.SerialConnectionOptions.BaudRates);
+            this.comboBoxSerialSpeed.SelectedItem = Utils.SerialConnectionOptions.DefaultBaudRate;
+            this.comboBoxSerialDataBits.Items.Clear();
+            this.comboBoxSerialDataBits.Items.AddRange(Utils.SerialConnectionOptions.DataBits);
+            this.comboBoxSerialDataBits.SelectedItem = Utils.SerialConnectionOptions.DefaultDataBits;
+            this.comboBoxSerialStopBits.Items.Clear();
+            this.comboBoxSerialStopBits.Items.AddRange(Utils.SerialConnectionOptions.StopBits);
+            this.comboBoxSerialStopBits.SelectedItem = Utils.SerialConnectionOptions.DefaultStopBits;
+            this.comboBoxSerialParity.Items.Clear();
+            this.comboBoxSerialParity.Items.AddRange(Utils.SerialConnectionOptions.Parity);
+            this.comboBoxSerialParity.SelectedItem = Utils.SerialConnectionOptions.DefaultParity;
+            this.comboBoxSerialFlowCtrl.Items.Clear();
+            this.comboBoxSerialFlowCtrl.Items.AddRange(Utils.SerialConnectionOptions.FlowControl);
+            this.comboBoxSerialFlowCtrl.SelectedItem = Utils.SerialConnectionOptions.DefaultFlowControl;
+
+            // Update the selection options to show IP port or serial port options:
+            radioButtonSerial_CheckedChanged();
+
             this.isInitialized = true;
         }
 
@@ -458,5 +481,14 @@ namespace SuperPutty
            //if extra Args contains a password, change the backgroudn
            textBoxExtraArgs.BackColor = String.IsNullOrEmpty(CommandLineOptions.getcommand(textBoxExtraArgs.Text, "-pw")) ? Color.White : Color.LightCoral;
        }
+
+        private void radioButtonSerial_CheckedChanged(object sender=null, EventArgs e=null)
+        {
+            // Whenever the Serial option is selected/deselected, we will re-configure the GUI to show
+            // the appropriate options.
+            this.panelIpConnection.Visible = !radioButtonSerial.Checked;
+            this.panelSerialConnSettings.Visible = radioButtonSerial.Checked;
+
+        }
     }
 }

--- a/SuperPutty/dlgEditSession.cs
+++ b/SuperPutty/dlgEditSession.cs
@@ -62,6 +62,7 @@ namespace SuperPutty
                 this.textBoxSPSLScriptFile.Text = Session.SPSLFileName;
                 this.textBoxRemotePathSesion.Text = Session.RemotePath;
                 this.textBoxLocalPathSesion.Text = Session.LocalPath;
+                InitializeSerialComboBoxes();
 
                 switch (Session.Proto)
                 {
@@ -122,25 +123,7 @@ namespace SuperPutty
                 : Session.ImageKey;
             this.toolTip.SetToolTip(this.buttonImageSelect, buttonImageSelect.ImageKey);
 
-            this.comboBoxSerialLine.Items.Clear();
-            this.comboBoxSerialLine.Items.AddRange(System.IO.Ports.SerialPort.GetPortNames());
-            if(this.comboBoxSerialLine.Items.Count > 0)
-                this.comboBoxSerialLine.SelectedIndex = 0;
-            this.comboBoxSerialSpeed.Items.Clear();
-            this.comboBoxSerialSpeed.Items.AddRange(Utils.SerialConnectionOptions.BaudRates);
-            this.comboBoxSerialSpeed.SelectedItem = Utils.SerialConnectionOptions.DefaultBaudRate;
-            this.comboBoxSerialDataBits.Items.Clear();
-            this.comboBoxSerialDataBits.Items.AddRange(Utils.SerialConnectionOptions.DataBits);
-            this.comboBoxSerialDataBits.SelectedItem = Utils.SerialConnectionOptions.DefaultDataBits;
-            this.comboBoxSerialStopBits.Items.Clear();
-            this.comboBoxSerialStopBits.Items.AddRange(Utils.SerialConnectionOptions.StopBits);
-            this.comboBoxSerialStopBits.SelectedItem = Utils.SerialConnectionOptions.DefaultStopBits;
-            this.comboBoxSerialParity.Items.Clear();
-            this.comboBoxSerialParity.Items.AddRange(Utils.SerialConnectionOptions.Parity);
-            this.comboBoxSerialParity.SelectedItem = Utils.SerialConnectionOptions.DefaultParity;
-            this.comboBoxSerialFlowCtrl.Items.Clear();
-            this.comboBoxSerialFlowCtrl.Items.AddRange(Utils.SerialConnectionOptions.FlowControl);
-            this.comboBoxSerialFlowCtrl.SelectedItem = Utils.SerialConnectionOptions.DefaultFlowControl;
+
 
             // Update the selection options to show IP port or serial port options:
             radioButtonSerial_CheckedChanged();
@@ -194,8 +177,14 @@ namespace SuperPutty
             Session.SessionId    = SessionData.CombineSessionIds(SessionData.GetSessionParentId(Session.SessionId), Session.SessionName);
             Session.ImageKey     = buttonImageSelect.ImageKey;
             Session.SPSLFileName = textBoxSPSLScriptFile.Text.Trim();
-            Session.RemotePath = textBoxRemotePathSesion.Text.Trim();
-            Session.LocalPath = textBoxLocalPathSesion.Text.Trim();
+            Session.RemotePath   = textBoxRemotePathSesion.Text.Trim();
+            Session.LocalPath    = textBoxLocalPathSesion.Text.Trim();
+            Session.SerialLine   = comboBoxSerialLine.Text.ToString();
+            Session.SerialSpeed  = comboBoxSerialSpeed.Text.ToString();
+            Session.SerialDataBits = comboBoxSerialDataBits.Text.ToString();
+            Session.SerialStopBits = comboBoxSerialStopBits.Text.ToString();
+            Session.SerialParity = comboBoxSerialParity.Text.ToString();
+            Session.SerialFlowControl = comboBoxSerialFlowCtrl.Text.ToString();
 
             for (int i = 0; i < groupBox1.Controls.Count; i++)
             {
@@ -489,6 +478,16 @@ namespace SuperPutty
             this.panelIpConnection.Visible = !radioButtonSerial.Checked;
             this.panelSerialConnSettings.Visible = radioButtonSerial.Checked;
 
+        }
+
+        private void InitializeSerialComboBoxes()
+        {
+            SerialConnectionOptions.InitializeSerialPortCombo(comboBoxSerialLine, Session.SerialLine);
+            SerialConnectionOptions.InitializeSerialSpeedCombo(comboBoxSerialSpeed, Session.SerialSpeed);
+            SerialConnectionOptions.InitializeSerialStopBitsCombo(comboBoxSerialStopBits, Session.SerialStopBits);
+            SerialConnectionOptions.InitializeSerialDataBitsCombo(comboBoxSerialDataBits, Session.SerialDataBits);
+            SerialConnectionOptions.InitializeSerialParityCombo(comboBoxSerialParity, Session.SerialParity);
+            SerialConnectionOptions.InitializeSerialFlowCtrlCombo(comboBoxSerialFlowCtrl, Session.SerialFlowControl);
         }
     }
 }

--- a/SuperPutty/dlgEditSession.cs
+++ b/SuperPutty/dlgEditSession.cs
@@ -62,7 +62,6 @@ namespace SuperPutty
                 this.textBoxSPSLScriptFile.Text = Session.SPSLFileName;
                 this.textBoxRemotePathSesion.Text = Session.RemotePath;
                 this.textBoxLocalPathSesion.Text = Session.LocalPath;
-                InitializeSerialComboBoxes();
 
                 switch (Session.Proto)
                 {
@@ -115,6 +114,7 @@ namespace SuperPutty
                 this.buttonSave.Enabled = false;
             }
 
+            InitializeSerialComboBoxes();
 
             // Setup icon chooser
             this.buttonImageSelect.ImageList = iconList;

--- a/SuperPutty/frmSuperPutty.Designer.cs
+++ b/SuperPutty/frmSuperPutty.Designer.cs
@@ -110,13 +110,17 @@ namespace SuperPutty
             this.tsConnect = new System.Windows.Forms.ToolStrip();
             this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
             this.tbComboProtocol = new System.Windows.Forms.ToolStripComboBox();
-            this.toolStripLabel2 = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripLabelSerialPort = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripComboBoxSerialPort = new System.Windows.Forms.ToolStripComboBox();
+            this.toolStripLabelSerialSpeed = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripComboBoxSerialSpeed = new System.Windows.Forms.ToolStripComboBox();
+            this.toolStripLabelHost = new System.Windows.Forms.ToolStripLabel();
             this.tbTxtBoxHost = new System.Windows.Forms.ToolStripTextBox();
-            this.toolStripLabel3 = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripLabelLogin = new System.Windows.Forms.ToolStripLabel();
             this.tbTxtBoxLogin = new System.Windows.Forms.ToolStripTextBox();
-            this.toolStripLabel4 = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripLabelPassword = new System.Windows.Forms.ToolStripLabel();
             this.tbTxtBoxPassword = new System.Windows.Forms.ToolStripTextBox();
-            this.toolStripLabel5 = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripLabelSession = new System.Windows.Forms.ToolStripLabel();
             this.tbComboSession = new System.Windows.Forms.ToolStripComboBox();
             this.tbBtnConnect = new System.Windows.Forms.ToolStripButton();
             this.toolStripButtonClearFields = new System.Windows.Forms.ToolStripButton();
@@ -305,6 +309,14 @@ namespace SuperPutty
             this.sessionsToolStripMenuItem.Text = "&Sessions";
             this.sessionsToolStripMenuItem.Click += new System.EventHandler(this.sessionsToolStripMenuItem_Click);
             // 
+            // sessionDetailToolStripMenuItem
+            // 
+            this.sessionDetailToolStripMenuItem.Name = "sessionDetailToolStripMenuItem";
+            this.sessionDetailToolStripMenuItem.ShortcutKeyDisplayString = "";
+            this.sessionDetailToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
+            this.sessionDetailToolStripMenuItem.Text = "Session &Detail";
+            this.sessionDetailToolStripMenuItem.Click += new System.EventHandler(this.sessionDetailMenuItem_Click);
+            // 
             // layoutsToolStripMenuItem
             // 
             this.layoutsToolStripMenuItem.Name = "layoutsToolStripMenuItem";
@@ -421,7 +433,7 @@ namespace SuperPutty
             // toggleCommandMaskToolStripMenuItem
             // 
             this.toggleCommandMaskToolStripMenuItem.Name = "toggleCommandMaskToolStripMenuItem";
-            this.toggleCommandMaskToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift)
+            this.toggleCommandMaskToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.D8)));
             this.toggleCommandMaskToolStripMenuItem.Size = new System.Drawing.Size(269, 22);
             this.toggleCommandMaskToolStripMenuItem.Text = "Toggle &Command Mask";
@@ -500,7 +512,7 @@ namespace SuperPutty
             this.aboutSuperPuTTYToolStripMenuItem.Size = new System.Drawing.Size(175, 22);
             this.aboutSuperPuTTYToolStripMenuItem.Text = "&About SuperPuTTY";
             this.aboutSuperPuTTYToolStripMenuItem.Click += new System.EventHandler(this.aboutSuperPuttyToolStripMenuItem_Click);
-            // 
+            //
             // dockPanel1
             // 
             this.DockPanel.DefaultFloatWindowSize = new System.Drawing.Size(800, 600);
@@ -705,13 +717,17 @@ namespace SuperPutty
             this.tsConnect.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripLabel1,
             this.tbComboProtocol,
-            this.toolStripLabel2,
+            this.toolStripLabelHost,
             this.tbTxtBoxHost,
-            this.toolStripLabel3,
+            this.toolStripLabelSerialPort,
+            this.toolStripComboBoxSerialPort,
+            this.toolStripLabelSerialSpeed,
+            this.toolStripComboBoxSerialSpeed,
+            this.toolStripLabelLogin,
             this.tbTxtBoxLogin,
-            this.toolStripLabel4,
+            this.toolStripLabelPassword,
             this.tbTxtBoxPassword,
-            this.toolStripLabel5,
+            this.toolStripLabelSession,
             this.tbComboSession,
             this.tbBtnConnect,
             this.toolStripButtonClearFields});
@@ -739,11 +755,39 @@ namespace SuperPutty
             this.tbComboProtocol.Size = new System.Drawing.Size(70, 23);
             this.tbComboProtocol.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tbItemConnect_KeyPress);
             // 
-            // toolStripLabel2
+            // toolStripLabelSerialPort
             // 
-            this.toolStripLabel2.Name = "toolStripLabel2";
-            this.toolStripLabel2.Size = new System.Drawing.Size(32, 22);
-            this.toolStripLabel2.Text = "Host";
+            this.toolStripLabelSerialPort.Name = "toolStripLabelSerialPort";
+            this.toolStripLabelSerialPort.Size = new System.Drawing.Size(60, 24);
+            this.toolStripLabelSerialPort.Text = "Serial Port";
+            // 
+            // toolStripComboBoxSerialPort
+            // 
+            this.toolStripComboBoxSerialPort.AutoSize = false;
+            this.toolStripComboBoxSerialPort.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.toolStripComboBoxSerialPort.DropDownWidth = 75;
+            this.toolStripComboBoxSerialPort.Name = "toolStripComboBoxSerialPort";
+            this.toolStripComboBoxSerialPort.Size = new System.Drawing.Size(70, 23);
+            // 
+            // toolStripLabelSerialSpeed
+            // 
+            this.toolStripLabelSerialSpeed.Name = "toolStripLabelSerialSpeed";
+            this.toolStripLabelSerialSpeed.Size = new System.Drawing.Size(60, 24);
+            this.toolStripLabelSerialSpeed.Text = "Speed";
+            // 
+            // toolStripComboBoxSerialSpeed
+            // 
+            this.toolStripComboBoxSerialSpeed.AutoSize = false;
+            this.toolStripComboBoxSerialSpeed.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.toolStripComboBoxSerialSpeed.DropDownWidth = 75;
+            this.toolStripComboBoxSerialSpeed.Name = "toolStripComboBoxSerialSpeed";
+            this.toolStripComboBoxSerialSpeed.Size = new System.Drawing.Size(70, 23);
+            // 
+            // toolStripLabelHost
+            // 
+            this.toolStripLabelHost.Name = "toolStripLabelHost";
+            this.toolStripLabelHost.Size = new System.Drawing.Size(32, 24);
+            this.toolStripLabelHost.Text = "Host";
             // 
             // tbTxtBoxHost
             // 
@@ -751,11 +795,11 @@ namespace SuperPutty
             this.tbTxtBoxHost.Size = new System.Drawing.Size(180, 25);
             this.tbTxtBoxHost.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tbItemConnect_KeyPress);
             // 
-            // toolStripLabel3
+            // toolStripLabelLogin
             // 
-            this.toolStripLabel3.Name = "toolStripLabel3";
-            this.toolStripLabel3.Size = new System.Drawing.Size(37, 22);
-            this.toolStripLabel3.Text = "Login";
+            this.toolStripLabelLogin.Name = "toolStripLabelLogin";
+            this.toolStripLabelLogin.Size = new System.Drawing.Size(37, 22);
+            this.toolStripLabelLogin.Text = "Login";
             // 
             // tbTxtBoxLogin
             // 
@@ -763,11 +807,11 @@ namespace SuperPutty
             this.tbTxtBoxLogin.Size = new System.Drawing.Size(100, 25);
             this.tbTxtBoxLogin.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tbItemConnect_KeyPress);
             // 
-            // toolStripLabel4
+            // toolStripLabelPassword
             // 
-            this.toolStripLabel4.Name = "toolStripLabel4";
-            this.toolStripLabel4.Size = new System.Drawing.Size(57, 22);
-            this.toolStripLabel4.Text = "Password";
+            this.toolStripLabelPassword.Name = "toolStripLabelPassword";
+            this.toolStripLabelPassword.Size = new System.Drawing.Size(57, 22);
+            this.toolStripLabelPassword.Text = "Password";
             // 
             // tbTxtBoxPassword
             // 
@@ -775,11 +819,11 @@ namespace SuperPutty
             this.tbTxtBoxPassword.Size = new System.Drawing.Size(100, 25);
             this.tbTxtBoxPassword.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.tbItemConnect_KeyPress);
             // 
-            // toolStripLabel5
+            // toolStripLabelSession
             // 
-            this.toolStripLabel5.Name = "toolStripLabel5";
-            this.toolStripLabel5.Size = new System.Drawing.Size(46, 22);
-            this.toolStripLabel5.Text = "Session";
+            this.toolStripLabelSession.Name = "toolStripLabelSession";
+            this.toolStripLabelSession.Size = new System.Drawing.Size(46, 22);
+            this.toolStripLabelSession.Text = "Session";
             // 
             // tbComboSession
             // 
@@ -840,7 +884,7 @@ namespace SuperPutty
             this.exitSuperPuTTYToolStripMenuItem.Size = new System.Drawing.Size(160, 22);
             this.exitSuperPuTTYToolStripMenuItem.Text = "Exit SuperPuTTY";
             this.exitSuperPuTTYToolStripMenuItem.Click += new System.EventHandler(this.exitSuperPuTTYToolStripMenuItem_Click);
-            // 
+            //
             // sessionDetailToolStripMenuItem
             // 
             this.sessionDetailToolStripMenuItem.Name = "sessionDetailToolStripMenuItem";
@@ -913,13 +957,13 @@ namespace SuperPutty
         private System.Windows.Forms.ToolStrip tsConnect;
         private System.Windows.Forms.ToolStripLabel toolStripLabel1;
         private System.Windows.Forms.ToolStripComboBox tbComboProtocol;
-        private System.Windows.Forms.ToolStripLabel toolStripLabel2;
+        private System.Windows.Forms.ToolStripLabel toolStripLabelHost;
         private System.Windows.Forms.ToolStripTextBox tbTxtBoxHost;
-        private System.Windows.Forms.ToolStripLabel toolStripLabel3;
+        private System.Windows.Forms.ToolStripLabel toolStripLabelLogin;
         private System.Windows.Forms.ToolStripTextBox tbTxtBoxLogin;
-        private System.Windows.Forms.ToolStripLabel toolStripLabel4;
+        private System.Windows.Forms.ToolStripLabel toolStripLabelPassword;
         private System.Windows.Forms.ToolStripTextBox tbTxtBoxPassword;
-        private System.Windows.Forms.ToolStripLabel toolStripLabel5;
+        private System.Windows.Forms.ToolStripLabel toolStripLabelSession;
         private System.Windows.Forms.ToolStripComboBox tbComboSession;
         private System.Windows.Forms.ToolStripButton tbBtnConnect;
         private System.Windows.Forms.ToolStrip tsCommands;
@@ -964,5 +1008,9 @@ namespace SuperPutty
         private System.Windows.Forms.ToolStripMenuItem checkForUpdatesToolStripMenuItem;
         private System.Windows.Forms.ToolStripButton toolStripButtonRunScript;
         private System.Windows.Forms.ToolStripMenuItem sessionDetailToolStripMenuItem;
+        private System.Windows.Forms.ToolStripLabel toolStripLabelSerialPort;
+        private System.Windows.Forms.ToolStripComboBox toolStripComboBoxSerialPort;
+        private System.Windows.Forms.ToolStripLabel toolStripLabelSerialSpeed;
+        private System.Windows.Forms.ToolStripComboBox toolStripComboBoxSerialSpeed;
     }
 }

--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -185,6 +185,31 @@ namespace SuperPutty
 
             this.DockPanel.ContentAdded += DockPanel_ContentAdded;
             this.DockPanel.ContentRemoved += DockPanel_ContentRemoved;
+
+            this.tbComboProtocol.SelectedIndexChanged += TbComboProtocol_SelectedIndexChanged;
+            this.toolStripComboBoxSerialPort.Items.Clear();
+            this.toolStripComboBoxSerialPort.Items.AddRange(System.IO.Ports.SerialPort.GetPortNames());
+            if (this.toolStripComboBoxSerialPort.Items.Count > 0)
+                this.toolStripComboBoxSerialPort.SelectedIndex = 0;
+            this.toolStripComboBoxSerialSpeed.Items.Clear();
+            this.toolStripComboBoxSerialSpeed.Items.AddRange(Utils.SerialConnectionOptions.BaudRates);
+            this.toolStripComboBoxSerialSpeed.SelectedItem = Utils.SerialConnectionOptions.DefaultBaudRate;
+            TbComboProtocol_SelectedIndexChanged();
+        }
+
+        private void TbComboProtocol_SelectedIndexChanged(object sender=null, EventArgs e=null)
+        {
+            // Whenever the protocol is updated, we need to update the edit controls on the
+            // toolbar.
+            bool SerialSelected = (tbComboProtocol.SelectedItem.ToString() == "Serial");
+            toolStripLabelSerialPort.Visible = SerialSelected;
+            toolStripLabelSerialSpeed.Visible = SerialSelected;
+            toolStripComboBoxSerialPort.Visible = SerialSelected;
+            toolStripComboBoxSerialSpeed.Visible = SerialSelected;
+            toolStripLabelLogin.Visible = !SerialSelected;
+            toolStripLabelPassword.Visible = !SerialSelected;
+            tbTxtBoxLogin.Visible = !SerialSelected;
+            tbTxtBoxPassword.Visible = !SerialSelected;
         }
 
         private void TsCommandHistory_ListChanged(object sender, ListChangedEventArgs e)
@@ -1907,5 +1932,6 @@ namespace SuperPutty
                 this.Bounds = newBounds;
             }
         }
+
     }
 }

--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -1026,6 +1026,8 @@ namespace SuperPutty
                     Password = this.tbTxtBoxPassword.Text,
                     PuttySession = (string)this.tbComboSession.SelectedItem
                 };
+                session.SerialLine = toolStripComboBoxSerialPort.SelectedItem.ToString();
+                session.SerialSpeed = toolStripComboBoxSerialSpeed.SelectedItem.ToString();
                 SuperPuTTY.OpenSession(new SessionDataStartInfo { Session = session, UseScp = isScp });
                 oldHostName = this.tbTxtBoxHost.Text;
                 RefreshConnectionToolbarData();

--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -186,14 +186,10 @@ namespace SuperPutty
             this.DockPanel.ContentAdded += DockPanel_ContentAdded;
             this.DockPanel.ContentRemoved += DockPanel_ContentRemoved;
 
+            SerialConnectionOptions.InitializeSerialPortCombo(toolStripComboBoxSerialPort);
+            SerialConnectionOptions.InitializeSerialSpeedCombo(toolStripComboBoxSerialSpeed);
+
             this.tbComboProtocol.SelectedIndexChanged += TbComboProtocol_SelectedIndexChanged;
-            this.toolStripComboBoxSerialPort.Items.Clear();
-            this.toolStripComboBoxSerialPort.Items.AddRange(System.IO.Ports.SerialPort.GetPortNames());
-            if (this.toolStripComboBoxSerialPort.Items.Count > 0)
-                this.toolStripComboBoxSerialPort.SelectedIndex = 0;
-            this.toolStripComboBoxSerialSpeed.Items.Clear();
-            this.toolStripComboBoxSerialSpeed.Items.AddRange(Utils.SerialConnectionOptions.BaudRates);
-            this.toolStripComboBoxSerialSpeed.SelectedItem = Utils.SerialConnectionOptions.DefaultBaudRate;
             TbComboProtocol_SelectedIndexChanged();
         }
 


### PR DESCRIPTION
This enhancement to superputty is intended to fix #728 . The following updates were made:
- The 'SessionData' object was updated to store information about the serial connection
- The new/edit dialog was updated to show the serial port configuration when the connection type is Serial
- The toolbar was updated to show Serial connection information when the serial connection type is displayed.
- Putty argument generation was separated for the Serial port, since there are some unique options for the serial connection.