### PR TITLE
Make MRU tabswitcher more useful

### DIFF
--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -319,13 +319,7 @@ namespace SuperPutty
                 ToolWindowDocument window = this.DockPanel.ActiveDocument as ToolWindowDocument;
                 if (window != null)
                 {
-                    // If we aren't using Ctrl-Tab to move between panels,
-                    // i.e. we got here because the operator clicked on the
-                    // panel directly, then record it as the current panel.
-                    if (!this.tabSwitcher.IsSwitchingTabs)
-                    {
-                        this.tabSwitcher.CurrentDocument = window;
-                    }
+                    this.tabSwitcher.CurrentDocument = window;
 
                     ctlPuttyPanel p = window as ctlPuttyPanel;
                     if (p != null)


### PR DESCRIPTION
Hi,

at the moment MRU is more or less the same as the OpenOrder strategy but only allows one direction.
So I've:
* fixed handling of IsTabSwitching: due to the check in frmSuperPutty.cs it was never set to false after being true at least once
* pushed it down because it was not required elsewhere
* make the prev-shortcut a reverse MRU switcher

I've tryed to add a testcase but could't find a quick way to mock the window objects :/.