### PR TITLE
In child window of external process force invalidations of area for r…

### DIFF
--- a/SuperPutty/Utils/NativeMethods.cs
+++ b/SuperPutty/Utils/NativeMethods.cs
@@ -1339,6 +1339,9 @@ namespace SuperPutty.Utils
 
         [DllImport("user32.dll")]
         public static extern uint MapVirtualKey(uint uCode, uint uMapType);
+
+        [DllImport("user32.dll")]
+        public static extern bool InvalidateRect(IntPtr hWnd, IntPtr lpRect, bool bErase);
         #endregion
 
 

--- a/SuperPutty/ctlApplicationPanel.cs
+++ b/SuperPutty/ctlApplicationPanel.cs
@@ -159,6 +159,8 @@ DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
                 //Log.InfoFormat("[{0}] ReFocusPuTTY - puttyTab={1}, caller={2}", this.m_AppWin, this.Parent.Text, caller);
                 settingForeground = true;
                 result = NativeMethods.SetForegroundWindow(this.m_AppWin);
+                if (result)
+                    NativeMethods.InvalidateRect(this.m_AppWin, IntPtr.Zero, false);
                 Log.InfoFormat("[{0}] ReFocusPuTTY - puttyTab={1}, caller={2}, result={3}", this.m_AppWin, this.Parent.Text, caller, result);
             }
             //return (this.m_AppWin != null


### PR DESCRIPTION
…edraw, otherwise parts of window are blank until they receiver a click.

This is experimental change.
SuperPuTTY, especially then used inside RDP connection and has many KiTTY windows,
doesn't fully render the background ones(and sometimes even foreground) having 'rectangular holes' which are blank, until text selection with mouse attempted. During heavy console writes(Such as configure/make) lot's of artifacts occur with parts of old text overlapping the newer one, or remaining like a burn-in.
This change fixed all those issues for me, also I'm now running longer compilation test and meantime it runs great(Including in screen+over RDP), with CPU usage of SuperPuTTY remaining on a near 0% level. Took many tries/tests to find this specific approach(Other's lie UpdateWindow did nothing).