### PR TITLE
Added preliminary limited support for RDP cand Win-Cmd connections.

### DIFF
--- a/SuperPutty/Data/RDPDataHelper.cs
+++ b/SuperPutty/Data/RDPDataHelper.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Win32;
+using System.Web;
+using log4net;
+using System.Xml;
+using System.IO;
+using System.Linq;
+
+namespace SuperPutty.Data
+{
+    /// <summary>Helper methods used mostly for importing settings and session data from other applications</summary>
+    public class RDPDataHelper
+    {
+        public static readonly ILog Log = LogManager.GetLogger(typeof(RDPDataHelper));
+
+        public static RegistryKey RootAppKey
+        {
+            get
+            {
+                RegistryKey key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Terminal Server Client\Default");
+                return key;
+            }
+        }
+
+        public static List<SessionData> GetAllSessionsFromRegistry()
+        {
+            List<SessionData> sessions = new List<SessionData>();
+
+            RegistryKey key = RootAppKey;
+            if (key != null)
+            {
+                string[] cachedEntriesNames = key.GetValueNames();
+                foreach (string keyName in cachedEntriesNames)
+                {
+                    if (!keyName.StartsWith("MRU", StringComparison .CurrentCulture))
+                        continue;
+                    string sessionName = (string)key.GetValue(keyName,"",RegistryValueOptions.DoNotExpandEnvironmentNames);
+                    if (sessionName != null)
+                    {
+                        SessionData session = new SessionData
+                        {
+                            Host = sessionName,
+                            Port = 3389,
+                            Proto = 
+                                (ConnectionProtocol)
+                                    Enum.Parse(typeof (ConnectionProtocol),
+                                        "RDP", true),
+                            PuttySession = sessionName,
+                            SessionName = sessionName,
+                            Username = ""
+                        };
+                        sessions.Add(session);
+                    }
+                }
+            }
+
+            return sessions;
+        }
+    }
+}

--- a/SuperPutty/Data/SessionData.cs
+++ b/SuperPutty/Data/SessionData.cs
@@ -46,7 +46,10 @@ namespace SuperPutty.Data
         Serial,
         Cygterm,
         Mintty,
-        VNC
+        VNC,
+        RDP,
+        WINCMD,
+        PS
     }
 
     /// <summary>The main class containing configuration settings for a session</summary>
@@ -588,7 +591,7 @@ namespace SuperPutty.Data
                 return string.Format("{0}://{1}", this.Proto.ToString().ToLower(), this.Host);
             }
 
-            if (this.Proto == ConnectionProtocol.VNC)
+            if (this.Proto == ConnectionProtocol.VNC || this.Proto == ConnectionProtocol.RDP)
             {
                 if (this.Port == 0)
                     return string.Format("{0}://{1}", this.Proto.ToString().ToLower(), this.Host);

--- a/SuperPutty/SessionTreeview.cs
+++ b/SuperPutty/SessionTreeview.cs
@@ -296,7 +296,7 @@ namespace SuperPutty
             if (IsSessionNode(node) && node == treeView1.SelectedNode)
             {
                 SessionData sessionData = (SessionData)node.Tag;
-                SuperPuTTY.OpenPuttySession(sessionData);
+                SuperPuTTY.OpenProtoSession(sessionData);
             }
         }
 
@@ -612,7 +612,7 @@ namespace SuperPutty
                 }
                 foreach (SessionData session in sessions)
                 {
-                        SuperPuTTY.OpenPuttySession(session);
+                    SuperPuTTY.OpenProtoSession(session);
                 }
             }
         }

--- a/SuperPutty/SuperPuTTY.cs
+++ b/SuperPutty/SuperPuTTY.cs
@@ -422,14 +422,14 @@ namespace SuperPutty
 
         /// <summary>Retrieve a <seealso cref="SessionData"/> object and open a new putty window</summary>
         /// <param name="sessionId">A string containing the <seealso cref="SessionData.SessionId"/> of the session</param>
-        public static void OpenPuttySession(string sessionId)
+        public static void OpenProtoSession(string sessionId)
         {
-            OpenPuttySession(GetSessionById(sessionId));
+            OpenProtoSession(GetSessionById(sessionId));
         }
 
         /// <summary>Open a new putty window with its settings being passed in a <seealso cref="SessionData"/> object</summary>
         /// <param name="session">The <seealso cref="SessionData"/> object containing the settings</param>
-        public static ctlPuttyPanel OpenPuttySession(SessionData session)
+        public static ctlPuttyPanel OpenProtoSession(SessionData session)
         {
             Log.InfoFormat("Opening putty session, id={0}", session == null ? "" : session.SessionId);
             ctlPuttyPanel panel = null;
@@ -584,7 +584,7 @@ namespace SuperPutty
                 }
                 else
                 {
-                    SuperPuTTY.OpenPuttySession(ssi.Session);
+                    SuperPuTTY.OpenProtoSession(ssi.Session);
                 }
             }
         }
@@ -629,6 +629,14 @@ namespace SuperPutty
             Log.InfoFormat("Importing sessions from PuttyCM");
             List<SessionData> sessions = PuttyDataHelper.GetAllSessionsFromPuTTYCM(fileExport);
             ImportSessions(sessions, "ImportedFromPuTTYCM");
+        }
+
+        /// <summary>Import sessions from Windows Registry which were set by PuTTY or KiTTY and load them into the in-application sessions database</summary>
+        public static void ImportRDPSessionsFromWinReg()
+        {
+            Log.InfoFormat("Importing RDP sessions from Windows registry");
+            List<SessionData> sessions = RDPDataHelper.GetAllSessionsFromRegistry();
+            ImportSessions(sessions, "ImportRDPSessionsFromWinReg");
         }
 
         /// <summary>Import sessions from a from a List object into the specified folder</summary>

--- a/SuperPutty/SuperPutty.csproj
+++ b/SuperPutty/SuperPutty.csproj
@@ -190,6 +190,7 @@
     </Compile>
     <Compile Include="Data\LayoutData.cs" />
     <Compile Include="Data\PuttyDataHelper.cs" />
+    <Compile Include="Data\RDPDataHelper.cs" />
     <Compile Include="Data\SessionData.cs" />
     <Compile Include="Data\SessionDataStartInfo.cs" />
     <Compile Include="DebugLogViewer.cs">
@@ -274,6 +275,8 @@
     <Compile Include="Utils\HostConnectionString.cs" />
     <Compile Include="Utils\MinttyStartInfo.cs" />
     <Compile Include="Utils\VNCStartInfo.cs" />
+    <Compile Include="Utils\RDPStartInfo.cs" />
+    <Compile Include="Utils\WCMDStartInfo.cs" />
     <Compile Include="Utils\NativeMethods.cs" />
     <Compile Include="Utils\PortableSettingsProvider.cs" />
     <Compile Include="Utils\PropertyNotifiableObject.cs" />

--- a/SuperPutty/Utils/NativeMethods.cs
+++ b/SuperPutty/Utils/NativeMethods.cs
@@ -34,8 +34,12 @@ namespace SuperPutty.Utils
             SC_MAXIMIZE = 0xF030,
             SC_RESTORE = 0xF120,
             SWP_NOZORDER = 0x0004,
+            SWP_NOOWNERZORDER = 0x0200,
             SWP_ASYNCWINDOWPOS = 0x4000,
-            SWP_FRAMECHANGED = 0x0020;
+            SWP_FRAMECHANGED = 0x0020,
+            SWP_NOMOVE = 0x0002,
+            SWP_NOSIZE = 0x0001,
+            SWP_NOACTIVATE = 0x0010;
 
         public const int
             ERROR_FILE_NOT_FOUND = 2,
@@ -48,12 +52,16 @@ namespace SuperPutty.Utils
             WH_MOUSE_LL = 0x000e,
             WS_CAPTION = 0x00C00000,
             WS_BORDER = 0x00800000,
+            WS_HSCROLL = 0x00100000,
             WS_VSCROLL = 0x00200000,
             WS_THICKFRAME = 0x00040000,
             WS_MAXIMIZE = 0x01000000,
+            WS_DLGFRAME = 0x00400000,
             WS_EX_APPWINDOW = 0x00040000,
             WS_EX_TOOLWINDOW = 0x00000080,
-            WS_EX_NOACTIVATE = 0x08000000;
+            WS_EX_NOACTIVATE = 0x08000000,
+            WS_CHILD = 0x40000000,
+            WS_VISIBLE = 0x10000000;
 
         public const uint
             KEYEVENTF_EXTENDEDKEY = 0x0001,
@@ -1329,7 +1337,7 @@ namespace SuperPutty.Utils
         public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, int dwExtraInfo);
 
         [DllImport("user32.dll", EntryPoint = "SetWindowPos")]
-        public static extern IntPtr SetWindowPos(IntPtr hWnd, int hWndInsertAfter, int x, int Y, int cx, int cy, int wFlags);
+        public static extern IntPtr SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int Y, int cx, int cy, int wFlags);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         public static extern IntPtr GetParent(IntPtr hWnd);

--- a/SuperPutty/Utils/PuttyStartInfo.cs
+++ b/SuperPutty/Utils/PuttyStartInfo.cs
@@ -24,6 +24,12 @@ namespace SuperPutty.Utils
                 case ConnectionProtocol.VNC:
                     return TryParseEnvVars(SuperPuTTY.Settings.VNCExe);
 
+                case ConnectionProtocol.RDP:
+                    return Environment.ExpandEnvironmentVariables("%systemroot%\\system32\\mstsc.exe");
+
+                case ConnectionProtocol.WINCMD:
+                    return Environment.ExpandEnvironmentVariables("%systemroot%\\system32\\cmd.exe");
+
                 default:
                     return TryParseEnvVars(SuperPuTTY.Settings.PuttyExe);
             }
@@ -52,6 +58,18 @@ namespace SuperPutty.Utils
                 VNCStartInfo vnc = new VNCStartInfo(session);
                 this.Args = vnc.Args;
                 this.WorkingDir = vnc.StartingDir;
+            }
+            else if (session.Proto == ConnectionProtocol.RDP)
+            {
+                RDPStartInfo rdp = new RDPStartInfo(session);
+                this.Args = rdp.Args;
+                this.WorkingDir = rdp.StartingDir;
+            }
+            else if (session.Proto == ConnectionProtocol.WINCMD)
+            {
+                WCMDStartInfo wcmd = new WCMDStartInfo(session);
+                this.Args = wcmd.Args;
+                this.WorkingDir = wcmd.StartingDir;
             }
             else
             {

--- a/SuperPutty/Utils/RDPStartinfo.cs
+++ b/SuperPutty/Utils/RDPStartinfo.cs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017 Anish Sane https://stackoverflow.com/users/793796/anishsane
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions: 
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using log4net;
+using SuperPutty.Data;
+using System.Text.RegularExpressions;
+using System.IO;
+
+namespace SuperPutty.Utils
+{
+
+    /// <summary>
+    /// Helper class for RDP support
+    /// </summary>
+    public class RDPStartInfo
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(RDPStartInfo));
+
+        private SessionData session;
+
+        public RDPStartInfo(SessionData session)
+        {
+            this.session = session;
+            this.Args = "-v:" + session.Host;
+
+            if (session.Port != 0)
+                this.Args += ":" + session.Port.ToString() + " ";
+
+            if (!String.IsNullOrEmpty(session.ExtraArgs))
+                this.Args += session.ExtraArgs + " ";
+
+            this.Args += "/span";
+
+            this.StartingDir = "%userprofile%\\Desktop";
+        }
+
+        public string Args { get; set; }
+        public string StartingDir { get; set; }
+
+    }
+}

--- a/SuperPutty/Utils/WCMDStartInfo.cs
+++ b/SuperPutty/Utils/WCMDStartInfo.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017 Anish Sane https://stackoverflow.com/users/793796/anishsane
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions: 
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System;
+using log4net;
+using SuperPutty.Data;
+using System.Text.RegularExpressions;
+using System.IO;
+
+namespace SuperPutty.Utils
+{
+
+    /// <summary>
+    /// Helper class for WINCMD support
+    /// </summary>
+    public class WCMDStartInfo
+    {
+        private static readonly ILog Log = LogManager.GetLogger(typeof(WCMDStartInfo));
+
+        private SessionData session;
+
+        public WCMDStartInfo(SessionData session)
+        {
+            this.session = session;
+            this.Args = "";
+
+            this.StartingDir = "%userprofile%";
+        }
+
+        public string Args { get; set; }
+        public string StartingDir { get; set; }
+
+    }
+}

--- a/SuperPutty/ctlPuttyPanel.cs
+++ b/SuperPutty/ctlPuttyPanel.cs
@@ -94,7 +94,7 @@ namespace SuperPutty
 
         private void CreatePanel()
         {
-            this.AppPanel = new ApplicationPanel();
+            this.AppPanel = new ApplicationPanel(this.Session.Proto);
             this.SuspendLayout();            
             this.AppPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.AppPanel.ApplicationName = this.m_puttyStartInfo.Executable;
@@ -342,7 +342,7 @@ namespace SuperPutty
                     SessionData session = SuperPuTTY.GetSessionById(sessionId);
                     if (session != null)
                     {
-                        panel = SuperPuTTY.OpenPuttySession(session);
+                        panel = SuperPuTTY.OpenProtoSession(session);
                         if (panel == null)
                         {
                             Log.WarnFormat("Could not restore putty session, sessionId={0}", sessionId);
@@ -369,7 +369,7 @@ namespace SuperPutty
                         SessionData session = SuperPuTTY.GetSessionById(sessionId);
                         if (session != null)
                         {
-                            panel = SuperPuTTY.OpenPuttySession(session);
+                            panel = SuperPuTTY.OpenProtoSession(session);
                         }
                         else
                         {
@@ -389,7 +389,7 @@ namespace SuperPutty
  
         private void duplicateSessionToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            SuperPuTTY.OpenPuttySession(this.Session);
+            SuperPuTTY.OpenProtoSession(this.Session);
         }
 
         private void renameTabToolStripMenuItem_Click(object sender, EventArgs e)
@@ -431,7 +431,7 @@ namespace SuperPutty
             SessionData session = menuItem.Tag as SessionData;
             if (session != null)
             {
-                SuperPuTTY.OpenPuttySession(session);
+                SuperPuTTY.OpenProtoSession(session);
             }
         }
 

--- a/SuperPutty/dlgEditSession.Designer.cs
+++ b/SuperPutty/dlgEditSession.Designer.cs
@@ -36,14 +36,7 @@ namespace SuperPutty
             this.textBoxPort = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.radioButtonVNC = new System.Windows.Forms.RadioButton();
-            this.radioButtonMintty = new System.Windows.Forms.RadioButton();
-            this.radioButtonCygterm = new System.Windows.Forms.RadioButton();
-            this.radioButtonSerial = new System.Windows.Forms.RadioButton();
-            this.radioButtonSSH = new System.Windows.Forms.RadioButton();
-            this.radioButtonRlogin = new System.Windows.Forms.RadioButton();
-            this.radioButtonTelnet = new System.Windows.Forms.RadioButton();
-            this.radioButtonRaw = new System.Windows.Forms.RadioButton();
+            this.comboBoxProto = new System.Windows.Forms.ComboBox();
             this.textBoxExtraArgs = new System.Windows.Forms.TextBox();
             this.label6 = new System.Windows.Forms.Label();
             this.buttonSave = new System.Windows.Forms.Button();
@@ -141,14 +134,7 @@ namespace SuperPutty
             // 
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox1.Controls.Add(this.radioButtonVNC);
-            this.groupBox1.Controls.Add(this.radioButtonMintty);
-            this.groupBox1.Controls.Add(this.radioButtonCygterm);
-            this.groupBox1.Controls.Add(this.radioButtonSerial);
-            this.groupBox1.Controls.Add(this.radioButtonSSH);
-            this.groupBox1.Controls.Add(this.radioButtonRlogin);
-            this.groupBox1.Controls.Add(this.radioButtonTelnet);
-            this.groupBox1.Controls.Add(this.radioButtonRaw);
+            this.groupBox1.Controls.Add(this.comboBoxProto);
             this.groupBox1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.groupBox1.Location = new System.Drawing.Point(14, 117);
             this.groupBox1.Name = "groupBox1";
@@ -157,110 +143,17 @@ namespace SuperPutty
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Connection type:";
             // 
-            // radioButtonVNC
+            // comboBoxProto
             // 
-            this.radioButtonVNC.AutoSize = true;
-            this.radioButtonVNC.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radioButtonVNC.Location = new System.Drawing.Point(432, 19);
-            this.radioButtonVNC.Name = "radioButtonVNC";
-            this.radioButtonVNC.Size = new System.Drawing.Size(49, 19);
-            this.radioButtonVNC.TabIndex = 9;
-            this.radioButtonVNC.Tag = SuperPutty.Data.ConnectionProtocol.VNC;
-            this.radioButtonVNC.Text = "VNC";
-            this.radioButtonVNC.UseVisualStyleBackColor = true;
-            this.radioButtonVNC.CheckedChanged += new System.EventHandler(this.radioButtonVNC_CheckedChanged);
-            // 
-            // radioButtonMintty
-            // 
-            this.radioButtonMintty.AutoSize = true;
-            this.radioButtonMintty.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radioButtonMintty.Location = new System.Drawing.Point(367, 19);
-            this.radioButtonMintty.Name = "radioButtonMintty";
-            this.radioButtonMintty.Size = new System.Drawing.Size(60, 19);
-            this.radioButtonMintty.TabIndex = 9;
-            this.radioButtonMintty.Tag = SuperPutty.Data.ConnectionProtocol.Mintty;
-            this.radioButtonMintty.Text = "Mintty";
-            this.radioButtonMintty.UseVisualStyleBackColor = true;
-            this.radioButtonMintty.CheckedChanged += new System.EventHandler(this.radioButtonCygterm_CheckedChanged);
-            // 
-            // radioButtonCygterm
-            // 
-            this.radioButtonCygterm.AutoSize = true;
-            this.radioButtonCygterm.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radioButtonCygterm.Location = new System.Drawing.Point(292, 19);
-            this.radioButtonCygterm.Name = "radioButtonCygterm";
-            this.radioButtonCygterm.Size = new System.Drawing.Size(71, 19);
-            this.radioButtonCygterm.TabIndex = 8;
-            this.radioButtonCygterm.Tag = SuperPutty.Data.ConnectionProtocol.Cygterm;
-            this.radioButtonCygterm.Text = "Cygterm";
-            this.radioButtonCygterm.UseVisualStyleBackColor = true;
-            this.radioButtonCygterm.CheckedChanged += new System.EventHandler(this.radioButtonCygterm_CheckedChanged);
-            // 
-            // radioButtonSerial
-            // 
-            this.radioButtonSerial.AutoSize = true;
-            this.radioButtonSerial.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radioButtonSerial.Location = new System.Drawing.Point(235, 19);
-            this.radioButtonSerial.Name = "radioButtonSerial";
-            this.radioButtonSerial.Size = new System.Drawing.Size(53, 19);
-            this.radioButtonSerial.TabIndex = 7;
-            this.radioButtonSerial.Tag = SuperPutty.Data.ConnectionProtocol.Serial;
-            this.radioButtonSerial.Text = "Serial";
-            this.radioButtonSerial.UseVisualStyleBackColor = true;
-            // 
-            // radioButtonSSH
-            // 
-            this.radioButtonSSH.AutoSize = true;
-            this.radioButtonSSH.Checked = true;
-            this.radioButtonSSH.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radioButtonSSH.Location = new System.Drawing.Point(185, 19);
-            this.radioButtonSSH.Name = "radioButtonSSH";
-            this.radioButtonSSH.Size = new System.Drawing.Size(46, 19);
-            this.radioButtonSSH.TabIndex = 6;
-            this.radioButtonSSH.TabStop = true;
-            this.radioButtonSSH.Tag = SuperPutty.Data.ConnectionProtocol.SSH;
-            this.radioButtonSSH.Text = "SSH";
-            this.radioButtonSSH.UseVisualStyleBackColor = true;
-            this.radioButtonSSH.CheckedChanged += new System.EventHandler(this.radioButtonSSH_CheckedChanged);
-            // 
-            // radioButtonRlogin
-            // 
-            this.radioButtonRlogin.AutoSize = true;
-            this.radioButtonRlogin.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radioButtonRlogin.Location = new System.Drawing.Point(119, 19);
-            this.radioButtonRlogin.Name = "radioButtonRlogin";
-            this.radioButtonRlogin.Size = new System.Drawing.Size(62, 19);
-            this.radioButtonRlogin.TabIndex = 5;
-            this.radioButtonRlogin.Tag = SuperPutty.Data.ConnectionProtocol.Rlogin;
-            this.radioButtonRlogin.Text = "RLogin";
-            this.radioButtonRlogin.UseVisualStyleBackColor = true;
-            this.radioButtonRlogin.CheckedChanged += new System.EventHandler(this.radioButtonRlogin_CheckedChanged);
-            // 
-            // radioButtonTelnet
-            // 
-            this.radioButtonTelnet.AutoSize = true;
-            this.radioButtonTelnet.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radioButtonTelnet.Location = new System.Drawing.Point(57, 19);
-            this.radioButtonTelnet.Name = "radioButtonTelnet";
-            this.radioButtonTelnet.Size = new System.Drawing.Size(57, 19);
-            this.radioButtonTelnet.TabIndex = 4;
-            this.radioButtonTelnet.Tag = SuperPutty.Data.ConnectionProtocol.Telnet;
-            this.radioButtonTelnet.Text = "Telnet";
-            this.radioButtonTelnet.UseVisualStyleBackColor = true;
-            this.radioButtonTelnet.CheckedChanged += new System.EventHandler(this.radioButtonTelnet_CheckedChanged);
-            // 
-            // radioButtonRaw
-            // 
-            this.radioButtonRaw.AutoSize = true;
-            this.radioButtonRaw.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.radioButtonRaw.Location = new System.Drawing.Point(6, 19);
-            this.radioButtonRaw.Name = "radioButtonRaw";
-            this.radioButtonRaw.Size = new System.Drawing.Size(47, 19);
-            this.radioButtonRaw.TabIndex = 3;
-            this.radioButtonRaw.Tag = SuperPutty.Data.ConnectionProtocol.Raw;
-            this.radioButtonRaw.Text = "Raw";
-            this.radioButtonRaw.UseVisualStyleBackColor = true;
-            this.radioButtonRaw.CheckedChanged += new System.EventHandler(this.radioButtonRaw_CheckedChanged);
+            this.comboBoxProto.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.comboBoxProto.FormattingEnabled = true;
+            this.comboBoxProto.Location = new System.Drawing.Point(136, 19);
+            this.comboBoxProto.Name = "comboBoxProto";
+            this.comboBoxProto.Size = new System.Drawing.Size(349, 21);
+            this.comboBoxProto.TabIndex = 1;
+            this.comboBoxProto.SelectedIndexChanged += new System.EventHandler(this.comboBoxPuttyProfile_SelectedIndexChanged);
+            this.comboBoxProto.Validating += new System.ComponentModel.CancelEventHandler(this.comboBoxPuttyProfile_Validating);
             // 
             // textBoxExtraArgs
             // 
@@ -540,11 +433,7 @@ namespace SuperPutty
         private System.Windows.Forms.TextBox textBoxPort;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.RadioButton radioButtonSerial;
-        private System.Windows.Forms.RadioButton radioButtonSSH;
-        private System.Windows.Forms.RadioButton radioButtonRlogin;
-        private System.Windows.Forms.RadioButton radioButtonTelnet;
-        private System.Windows.Forms.RadioButton radioButtonRaw;
+        private System.Windows.Forms.ComboBox comboBoxProto;
         private System.Windows.Forms.Button buttonSave;
         private System.Windows.Forms.Button buttonCancel;
         private System.Windows.Forms.Label label4;
@@ -552,12 +441,9 @@ namespace SuperPutty
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.TextBox textBoxUsername;
-        private System.Windows.Forms.RadioButton radioButtonCygterm;
         private System.Windows.Forms.ErrorProvider errorProvider;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.TextBox textBoxExtraArgs;
-        private System.Windows.Forms.RadioButton radioButtonMintty;
-        private System.Windows.Forms.RadioButton radioButtonVNC;
         private System.Windows.Forms.Button buttonImageSelect;
         private System.Windows.Forms.ToolTip toolTip;
         private System.Windows.Forms.Label label7;

--- a/SuperPutty/frmSuperPutty.Designer.cs
+++ b/SuperPutty/frmSuperPutty.Designer.cs
@@ -54,6 +54,7 @@ namespace SuperPutty
             this.fromPuTTYSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fromPuTTYPortableSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.fromPuTTYCMExportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.fromWinRDPRegToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem7 = new System.Windows.Forms.ToolStripSeparator();
             this.openSessionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -178,7 +179,8 @@ namespace SuperPutty
             this.fromFileToolStripMenuItem,
             this.fromPuTTYSettingsToolStripMenuItem,
             this.fromPuTTYPortableSettingsToolStripMenuItem,
-            this.fromPuTTYCMExportToolStripMenuItem});
+            this.fromPuTTYCMExportToolStripMenuItem,
+            this.fromWinRDPRegToolStripMenuItem});
             this.importSettingsToolStripMenuItem.Name = "importSettingsToolStripMenuItem";
             this.importSettingsToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
             this.importSettingsToolStripMenuItem.Text = "&Import Sessions";
@@ -210,6 +212,13 @@ namespace SuperPutty
             this.fromPuTTYCMExportToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
             this.fromPuTTYCMExportToolStripMenuItem.Text = "From PuTTY &CM Export";
             this.fromPuTTYCMExportToolStripMenuItem.Click += new System.EventHandler(this.fromPuTTYCMExportToolStripMenuItem_Click);
+            // 
+            // fromWinRDPRegToolStripMenuItem
+            // 
+            this.fromWinRDPRegToolStripMenuItem.Name = "fromWinRDPRegToolStripMenuItem";
+            this.fromWinRDPRegToolStripMenuItem.Size = new System.Drawing.Size(198, 22);
+            this.fromWinRDPRegToolStripMenuItem.Text = "RDP - From Win &Registry";
+            this.fromWinRDPRegToolStripMenuItem.Click += new System.EventHandler(this.fromWinRDPRegToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
@@ -948,6 +957,7 @@ namespace SuperPutty
         private System.Windows.Forms.ToolStripMenuItem fromPuTTYSettingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fromPuTTYPortableSettingsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fromPuTTYCMExportToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem fromWinRDPRegToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem sessionsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem layoutsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem logViewerToolStripMenuItem;

--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -405,7 +405,7 @@ namespace SuperPutty
             }
         }
 
-        private void fromPuTTYPortableSettingsToolStripMenuItem_Click(object sender, EventArgs e) /// //
+        private void fromPuTTYPortableSettingsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             FolderBrowserDialog openDialog = new FolderBrowserDialog
             {
@@ -416,6 +416,18 @@ namespace SuperPutty
             if (openDialog.ShowDialog(this) == DialogResult.OK)
             {
                 SuperPuTTY.ImportSessionsFromFolder(openDialog.SelectedPath);
+            }
+        }
+
+        private void fromWinRDPRegToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            DialogResult res = MessageBox.Show(
+                "Do you want to copy all RDP sessions from registry cache?  Duplicates may be created.",
+                "SuperPuTTY",
+                MessageBoxButtons.YesNo);
+            if (res == DialogResult.Yes)
+            {
+                SuperPuTTY.ImportRDPSessionsFromWinReg();
             }
         }
 
@@ -445,7 +457,7 @@ namespace SuperPutty
             QuickSelector d = new QuickSelector();
             if (d.ShowDialog(this, data, opt) == DialogResult.OK)
             {
-                SuperPuTTY.OpenPuttySession(d.SelectedItem.Detail);
+                SuperPuTTY.OpenProtoSession(d.SelectedItem.Detail);
             }
         }
 
@@ -1542,7 +1554,7 @@ namespace SuperPutty
                     break;
                 case SuperPuttyAction.DuplicateSession:
                     if (activePanel != null && activePanel.Session != null)
-                        SuperPuTTY.OpenPuttySession(activePanel.Session);
+                        SuperPuTTY.OpenProtoSession(activePanel.Session);
                     break;
                 case SuperPuttyAction.GotoCommandBar:
                     if (!this.fullscreenViewState.IsFullScreen)
@@ -1895,7 +1907,7 @@ namespace SuperPutty
 
             if (this.WindowState == FormWindowState.Maximized)
             {
-                NativeMethods.SetWindowPos(this.Handle, 0,
+                NativeMethods.SetWindowPos(this.Handle, IntPtr.Zero,
                     nextScreen.Bounds.X, nextScreen.Bounds.Y, nextScreen.Bounds.Width, nextScreen.Bounds.Height,
                     NativeMethods.SWP_NOZORDER | NativeMethods.SWP_ASYNCWINDOWPOS | NativeMethods.SWP_FRAMECHANGED);
             }


### PR DESCRIPTION
This is big WIP, part 1.
Adds initial RDP support as for #685 - Init/Middle state
Details:
1) Client first opens in full screen, Needs restore it to get SP catch it. - Need to investigate 
2) Hard to get the RDP window to be owned(parent-ed) by SP. This causes RDP clieet to left as external window, not tracked by SP. Only pos/size is somewhat changed
3) Flashing foreground icon of SP in taskbar then RDP is open - Fixed, but too many things rely on focus hijacking. Unfortunately for RDP focus track shall be disabled, or maybe enabled in very limited fasdhion(1 QPS).
Adds initial WinCmd support - Seems to be basically working.

Changes:
Connection Edit - Changed protocol selection from radio buttons to combobox. For VNC require the port and use RFC 5900 as default(Was blank previously).
For RDP also implemented import from OS recent terminal servers list import.

Challenges:
Make SP consistently and reliably take parentship of RDP process, while on the way taking parenthip of middle processes, especially "Auth Window" - Owning it helps to avoid it being minimized by OS.
The problem is with 2-nd and 3-rd windows while 3-rd is child of 2-nd and it's a final one. This nesting of windows in RDP causes the most headache, to make it work.
I'll need your advice, relying on your knowledge of code and hacks hidden inside windows and focus management. Thanks.
One of changes made is that id window is of 'dialog'
 type - no focus hijacking will be attempted on them, to allow user to enter info into those, w/o SP taking focus.

Rewrote to not touch the ReFocusPuTTY - only use the main first loop and extend time for RDP. Inheritance now works and foreground  tracing code is not disabled. However RDP "Auth" window now blocks the SP load till auth completes, so SP doesn't even fully draw till that.. Possibly the window searching part can be made threaded in the future... Also scroll-bars are missing from this internal window.


Need CR.