### PR TITLE
Made the application DPI aware

### DIFF
--- a/SuperPutty/App.config
+++ b/SuperPutty/App.config
@@ -16,6 +16,7 @@
     <!-- <add key="SuperPuTTY.XMLEditor" value="C:\Program Files (x86)\Notepad++\notepad++.exe" /> -->
     <add key="SuperPuTTY.XMLEditor" value="notepad"/>
     <add key="SuperPuTTY.MaxSessionsToOpen" value="10"/>
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
   </appSettings>
   
   <log4net debug="false">

--- a/SuperPutty/Gui/DpiUtils.cs
+++ b/SuperPutty/Gui/DpiUtils.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace SuperPutty.Gui
+{
+    public class DpiUtils
+    {
+        [DllImport("gdi32.dll")]
+        public static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern IntPtr GetDC(IntPtr hWnd);
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+        /// <summary>
+        /// Taken from https://oliversturm.com/blog/2010/09/02/the-crime-that-is-windows-dpi-handling/
+        /// </summary>
+        /// <returns>The current scren DPI</returns>
+        public static Size GetScreenDPI()
+        {
+            // no error checking here - being lazy
+            var dc = GetDC(IntPtr.Zero);
+            try
+            {
+                return new Size(
+                  GetDeviceCaps(dc, (int)DeviceCap.LOGPIXELSX),
+                  GetDeviceCaps(dc, (int)DeviceCap.LOGPIXELSY)
+                );
+            }
+            finally
+            {
+                ReleaseDC(IntPtr.Zero, dc);
+            }
+        }
+
+        public static int ScaleWidth(int originalWidth)
+        {
+            return (int)(originalWidth / 96f * GetScreenDPI().Width);
+        }
+
+        public static int ScaleHeight(int originalHeight)
+        {
+            return (int)(originalHeight / 96f * GetScreenDPI().Height);
+        }
+
+        public static Size ScaleSize(Size originalSize)
+        {
+            return new Size(ScaleWidth(originalSize.Width), ScaleHeight(originalSize.Height));
+        }
+    }
+
+    enum DeviceCap
+    {
+        /// <summary>
+        /// Logical pixels inch in X
+        /// </summary>
+        LOGPIXELSX = 88,
+        /// <summary>
+        /// Logical pixels inch in Y
+        /// </summary>
+        LOGPIXELSY = 90
+    }
+}

--- a/SuperPutty/SessionTreeview.cs
+++ b/SuperPutty/SessionTreeview.cs
@@ -77,6 +77,7 @@ namespace SuperPutty
         public SessionTreeview(DockPanel dockPanel)
         {
             m_DockPanel = dockPanel;
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             InitializeComponent();
             this.treeView1.TreeViewNodeSorter = this;
             this.treeView1.HideSelection = false;

--- a/SuperPutty/SuperPutty.csproj
+++ b/SuperPutty/SuperPutty.csproj
@@ -61,6 +61,9 @@
   <PropertyGroup>
     <ApplicationIcon>Apps-utilities-terminal.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
@@ -101,6 +104,7 @@
     <Compile Include="GitRelease.cs" />
     <Compile Include="Gui\BaseViewModel.cs" />
     <Compile Include="Gui\DataGridViewProgressColumn.cs" />
+    <Compile Include="Gui\DpiUtils.cs" />
     <Compile Include="Gui\ImageListPopup.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -435,6 +439,7 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="app.manifest" />
     <None Include="Gui\QuickSelectorData.xsc">
       <DependentUpon>QuickSelectorData.xsd</DependentUpon>
     </None>

--- a/SuperPutty/app.manifest
+++ b/SuperPutty/app.manifest
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+	</windowsSettings>
+  </application>
+</assembly>

--- a/SuperPutty/dlgFindPutty.cs
+++ b/SuperPutty/dlgFindPutty.cs
@@ -45,7 +45,11 @@ namespace SuperPutty
 
         public dlgFindPutty()
         {
+            this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+
             InitializeComponent();
+
+            FixDpiScalingIssues();
 
             string puttyExe = SuperPuTTY.Settings.PuttyExe;
             string pscpExe = SuperPuTTY.Settings.PscpExe;
@@ -209,6 +213,12 @@ namespace SuperPutty
                 this.Shortcuts.Add(ks);
             }
             this.dataGridViewShortcuts.DataSource = this.Shortcuts;
+        }
+
+        private void FixDpiScalingIssues()
+        {
+            this.colEdit.Width = DpiUtils.ScaleWidth(this.colEdit.Width);
+            this.colClear.Width = DpiUtils.ScaleWidth(this.colClear.Width);
         }
 
 

--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -96,6 +96,8 @@ namespace SuperPutty
 
             InitializeComponent();
 
+            FixDpiScalingIssues();
+
             // force toolbar locations...designer likes to flip them around
             this.tsConnect.Location = new System.Drawing.Point(0, 24);
             this.tsCommands.Location = new System.Drawing.Point(0, 49);
@@ -190,6 +192,19 @@ namespace SuperPutty
 
             this.tsCommands.ImageList = SuperPuTTY.ImagesWithStop;
             this.toolStripButtonChooseIconGroup.ImageKey = "stop";
+        }
+
+        private void FixDpiScalingIssues()
+        {
+            this.tbComboProtocol.Size = DpiUtils.ScaleSize(this.tbComboProtocol.Size);
+            this.tbComboProtocol.DropDownWidth = DpiUtils.ScaleWidth(this.tbComboProtocol.DropDownWidth);
+            this.tbTxtBoxHost.Size = DpiUtils.ScaleSize(this.tbTxtBoxHost.Size);
+            this.tbTxtBoxLogin.Size = DpiUtils.ScaleSize(this.tbTxtBoxLogin.Size);
+            this.tbTxtBoxPassword.Size = DpiUtils.ScaleSize(this.tbTxtBoxPassword.Size);
+            this.tbComboSession.Size = DpiUtils.ScaleSize(this.tbComboSession.Size);
+
+            this.tsSendCommandCombo.Size = DpiUtils.ScaleSize(this.tsSendCommandCombo.Size);
+            this.tsSendCommandCombo.DropDownWidth = DpiUtils.ScaleWidth(this.tsSendCommandCombo.DropDownWidth);
         }
 
         private void TsCommandHistory_ListChanged(object sender, ListChangedEventArgs e)


### PR DESCRIPTION
This is an attempt at fixing #634.

There are a few issues remaining:
* This is my first time doing C# and .Net, so I might be doing it completely wrong 😄 
* I couldn't find a download link to the .NET Framework SDK 4.5, so I developed and tested with version 4.5.1 instead. This might be a good thing in fact, as it looks like ["Starting with .NET Framework 4.5.1, Microsoft made improvements for HDPI scenarios in Windows Forms."](https://www.telerik.com/blogs/winforms-scaling-at-large-dpi-settings-is-it-even-possible-)
* TextBoxes don't seem to scale correctly vertically (well they grow, but they should be as tall as the buttons near them I guess)
* ToolStrip icons are still low res, but I think it's because the resources themselves are 16x16
* I had to scale most of the ToolStrips' components manually, this feels unnecessary. I think it should be done automatically, so I might have missed something.
* Tool windows icons are super small, this might have been [fixed in a more recent version of dockpanelsuite](https://github.com/dockpanelsuite/dockpanelsuite/issues/366)
* TreeView icons are also super small, I couldn't make [the trick described on StackOverflow](https://stackoverflow.com/a/29766847) work ("Set ImageList.ImageSize according to CreateGraphics.DpiX and .DpiY")

HiDPI version:

![image](https://user-images.githubusercontent.com/281528/99440956-8e1a3180-2917-11eb-8e61-53b517dfb056.png)

HiDPI vs. current version:

![image](https://user-images.githubusercontent.com/281528/99442943-624c7b00-291a-11eb-8d21-7a1a2685a1e3.png)

Very useful resources I came across while doing research on HiDPI support in WinForms:
* https://www.telerik.com/blogs/winforms-scaling-at-large-dpi-settings-is-it-even-possible-
* https://stackoverflow.com/questions/22735174/how-to-write-winforms-code-that-auto-scales-to-system-font-and-dpi-settings
* https://docs.microsoft.com/en-us/dotnet/desktop/winforms/high-dpi-support-in-windows-forms?view=netframeworkdesktop-4.8
