### PR TITLE
Fix clearing Inputbox when CTRL+ALT or AltGR pressed

### DIFF
--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -1162,7 +1162,7 @@ namespace SuperPutty
                 e.Handled = true;
                 e.SuppressKeyPress = true;
             }
-            else if (e.Control && e.KeyCode != Keys.ControlKey)
+            else if (e.Control && e.KeyCode != Keys.ControlKey && !e.Alt)
             {
                 // special keys
                 TrySendCommandsFromToolbar(new CommandData(e), !this.tbBtnMaskText.Checked);


### PR DESCRIPTION
Fixes #642 - German Keyboard Layout is not able to input @ for example, input gets cleared and the @ is posted on all connected putty sessions.

Fix Ctrl+Alt or AltGR (german Keyboard) preventing @ or | for example