### PR TITLE
"Collections" - within the Sessions.XML config file, allow pointing to other Session XML configs. Collection locations and SPSLFileName locations can be File paths or URLs

### DIFF
--- a/SuperPutty/Program.cs
+++ b/SuperPutty/Program.cs
@@ -49,6 +49,8 @@ namespace SuperPutty
         [STAThread]
         static void Main(string[] args)
         {
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
+
             // send log to console
             log4net.Config.BasicConfigurator.Configure();
 

--- a/SuperPutty/Utils/PortableSettingsProvider.cs
+++ b/SuperPutty/Utils/PortableSettingsProvider.cs
@@ -187,12 +187,14 @@ namespace SuperPutty.Utils
                 if (UseRoamingSettings(setting))
                 {
                     XmlNode node = SettingsXML.SelectSingleNode(SettingsRoot + "/" + setting.Name);
+                    
                     if (node == null)
                     {
                         // try go by host...backwards compatibility
                         node = SettingsXML.SelectSingleNode(SettingsRoot + "/" + GetHostName() + "/" + setting.Name);
                     }
-                    value = node.InnerText;
+
+                    value = node?.InnerText ?? String.Empty;
                 }
                 else
                 {

--- a/SuperPutty/frmSuperPutty.cs
+++ b/SuperPutty/frmSuperPutty.cs
@@ -90,7 +90,6 @@ namespace SuperPutty
         /// <summary>The main SuperPuTTY application form</summary>
         public frmSuperPutty()
         {
-            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
             // Verify Putty is set; Prompt user if necessary; exit otherwise
             dlgFindPutty.PuttyCheck();
 


### PR DESCRIPTION
The key changes are:

1. Allow a SessionData entry that just has a CollectionID (optional) and CollectionLocation value. It will then pull in the SessionData entries in the config file specified by the CollectionLocation. An important change here is that CollectionLocation can be a URL or a local file. 
2. Allow SPSLFileName to be a URL as well as a local file. 

Some nuances:

- If CollectionID is specified, this is the folder that all the imported entries will be put under. 
- If a URL is specified in the CollectionLocation, then relative URLs are allowed (and will be handled properly) in the remote config file. 
- Collections can be nested.

Use Case:
I want to be able to create a CompanySessions.XML file for my company that points to all our servers. I can tell co-workers to "just add this entry" to their Sessions.XML file, which will be a URL hosted on company servers. The URL can be kept up to date without everyone having to go change their stuff. They can maintain personal settings as well which won't affect or be affected by the CompanySessions.XML file - those entries will all be added into a Company/ folder. 