### PR TITLE
Fix bug where SENDLINE doesn't always make distinct lines

### DIFF
--- a/SuperPutty/Scripting/SendLineCommand.cs
+++ b/SuperPutty/Scripting/SendLineCommand.cs
@@ -19,6 +19,7 @@
  * THE SOFTWARE.
  */
 
+using System;
 using System.Windows.Forms;
 using SuperPutty.Utils;
 
@@ -32,7 +33,7 @@ namespace SuperPuTTY.Scripting
         internal static CommandData SendLineHandler(string arg)
         {
             // TODO: parse the arguments and replace and variables with customized data
-            CommandData data = new CommandData(arg, new KeyEventArgs(Keys.Enter));
+            CommandData data = new CommandData(arg, new KeyEventArgs(Keys.Enter), TimeSpan.FromMilliseconds(50));
             return data;
         }
     }

--- a/SuperPutty/Utils/CommandData.cs
+++ b/SuperPutty/Utils/CommandData.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Text;
+using System.Threading;
 using System.Windows.Forms;
 using log4net;
 
@@ -35,6 +36,8 @@ namespace SuperPutty.Utils
         public string Command { get; private set; }
         /// <summary>Get the keystrokes to send</summary>
         public KeyEventArgs KeyData { get; private set; }
+
+        public TimeSpan Delay { get; private set; }
 
         /// <summary>Construct a new <seealso cref="CommandData"/> object, specifying a command to send</summary>
         /// <param name="command">A string containing the command to send</param>
@@ -58,7 +61,18 @@ namespace SuperPutty.Utils
             this.Command = command;
             this.KeyData = keys;
         }
-        
+
+        /// <summary>Construct a new <seealso cref="CommandData"/> object, specifying both a command and keyboard keystrokes to send</summary>
+        /// /// <param name="command">A string containing the command to send</param>
+        /// <param name="keys">A <seealso cref="KeyEventArgs"/> object containing the keyboard keystrokes</param>
+        /// <param name="delay">How long we should wait before executing next command</param>
+        public CommandData(string command, KeyEventArgs keys, TimeSpan delay)
+        {
+            this.Command = command;
+            this.KeyData = keys;
+            this.Delay = delay;
+        }
+
         /// <summary>Send commands and keystrokes to the specified session</summary>
         /// <param name="handle">The Windows Handle to send to</param>
         public void SendToTerminal(int handle)
@@ -70,7 +84,7 @@ namespace SuperPutty.Utils
                 foreach (Char c in this.Command)
                 {
                     NativeMethods.SendMessage(handle, NativeMethods.WM_CHAR, (int)c, 0);
-                }                
+                }
             }
 
             if (this.KeyData != null)
@@ -84,7 +98,12 @@ namespace SuperPutty.Utils
 
                 if (this.KeyData.Shift) { NativeMethods.PostMessage(handle, NativeMethods.WM_KEYUP, NativeMethods.VK_SHIFT, 0); }
                 if (this.KeyData.Control) { NativeMethods.PostMessage(handle, NativeMethods.WM_KEYUP, NativeMethods.VK_CONTROL, 0); }
-            }            
+            }
+
+            if (this.Delay > TimeSpan.Zero)
+            {
+                Thread.Sleep(this.Delay);
+            }
         }
         
         public override string ToString()


### PR DESCRIPTION
BUG: sending multiple SENDLINE commands in a row when connecting to a server sometimes (and inconsistently) makes screws up the commands. Might only happen when loading a profile.

**Example script:**
```
#!/bin/spsl
SENDLINE echo test1
SENDLINE echo test2
SENDLINE echo test3
SENDLINE echo test4
SENDLINE echo test5
SENDLINE echo test6
SENDLINE echo test7
SENDLINE echo test8
SENDLINE echo test9
SENDLINE echo test10
```
**Output**
```
> echo test1
test1
> echo test2
test2
> echo test3e
test3e
> cho test4

Command 'cho' not found...

> echo test5
test5
> echo test6
test6
> echo test7
test7
> echo test8
test8
> echo test9e
test9e
> cho test10

Command 'cho' not found...
```



Fixed by delaying the execution of the next command by 50ms for every SENDLINE command.