### PR TITLE
Children attach improvement

### DIFF
--- a/SuperPutty/ctlApplicationPanel.cs
+++ b/SuperPutty/ctlApplicationPanel.cs
@@ -152,7 +152,7 @@ DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
                 bool success = NativeMethods.MoveWindow(m_AppWin, x, y, this.Width, this.Height, this.Visible);
                 if (Log.IsInfoEnabled)
                 {
-                    Log.InfoFormat("MoveWindow [{3,-15}{4,20}] w={0,4}, h={1,4}, visible={2}, success={5}", this.Width, this.Height, this.Visible, src, this.Name, success);
+                    Log.InfoFormat("MoveWindow [{3,-15}{4,20}] w={0,4}, h={1,4}, visible={2}, success={5}, hnd={6}", this.Width, this.Height, this.Visible, src, this.Name, success, m_AppWin);
                 }
             }
         }
@@ -443,7 +443,7 @@ DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
                 m_AppWin = IntPtr.Zero;
                 try
                 {
-                    if(!File.Exists(ApplicationName))
+                    if (!File.Exists(ApplicationName))
                     {
                         MessageBox.Show(ApplicationName + " not found in configured path, please go into tools->settings and set the correct path", "Application Not Found");
                         return;
@@ -454,7 +454,8 @@ DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
                         StartInfo =
                         {
                             FileName = ApplicationName,
-                            Arguments = ApplicationParameters
+                            Arguments = ApplicationParameters,
+                            WindowStyle = ProcessWindowStyle.Maximized
                         }
                     };
 

--- a/SuperPutty/ctlApplicationPanel.cs
+++ b/SuperPutty/ctlApplicationPanel.cs
@@ -164,16 +164,12 @@ DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
                 this.MoveWindow("RestoreTabSwitch");
             if (this.ExternalProcessCaptured && NativeMethods.GetForegroundWindow() != this.m_AppWin)
             {
-                //Log.InfoFormat("[{0}] ReFocusPuTTY - puttyTab={1}, caller={2}", this.m_AppWin, this.Parent.Text, caller);
                 settingForeground = true;
                 result = NativeMethods.SetForegroundWindow(this.m_AppWin);
                 if (result)
                     NativeMethods.InvalidateRect(this.m_AppWin, IntPtr.Zero, false);
                 Log.InfoFormat("[{0}] ReFocusPuTTY - puttyTab={1}, caller={2}, result={3}", this.m_AppWin, this.Parent.Text, caller, result);
             }
-            //return (this.m_AppWin != null
-            //    && NativeMethods.GetForegroundWindow() != this.m_AppWin
-            //    && !NativeMethods.SetForegroundWindow(this.m_AppWin));
 
             return result;
         }
@@ -295,81 +291,6 @@ DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
             if (RefocusOnVisChanged && NativeMethods.GetForegroundWindow() != this.m_AppWin)
             {
                 this.BeginInvoke(new MethodInvoker(delegate { this.ReFocusPuTTY("OnVisChanged"); }));
-            }
-        }
-
-        private void __UNUSED_REFONLY_UpdateTrackedWindowHandle()
-        {
-            bool bNeedsUpdate = true;
-            if (this.b_AppWinFinal)
-                return;
-            switch (this.proto)
-            {
-                case SuperPutty.Data.ConnectionProtocol.RDP:
-                    Log.Info("Update track is called.");
-                    this.m_Process.Refresh();
-                    IntPtr winCandidate = this.m_Process.MainWindowHandle;
-                    Log.Info("Update, WinCnd="+((int)winCandidate));
-                    if (winCandidate == IntPtr.Zero || winCandidate == this.m_AppWin)
-                        break;
-                    NativeMethods.RECT rect = new NativeMethods.RECT();
-                    if (!NativeMethods.GetWindowRect(winCandidate, ref rect))
-                        break;
-                    int w = rect.Right - rect.Left;
-                    int h = rect.Bottom - rect.Top;
-                    Log.Info("Checking window handle [PID="+ this.m_Process.Id +"] to " + ((int)winCandidate) + ". Win size is " + w + "x" + h + ". Title is: " + this.m_Process.MainWindowTitle);
-                    if ((this.m_Process.MainWindowTitle.Contains(":") && this.m_Process.MainWindowTitle.Contains(" - Remote Desktop Connection")) /*|| (w >= 400 && h >= 120)*/) /* WIP - Heuristic using caption(Non-localized OS) or size for other cases, quite hacky till find better way */
-                    {
-                        //this.b_AppWinFinal = true;
-                        Log.Info("Updated window handle to " + ((int)winCandidate) + ". Win size is " + w + "x" + h + ". Title is: " + this.m_Process.MainWindowTitle);
-                        this.m_AppWin = winCandidate;
-                    }
-                    else if (this.m_Process.MainWindowTitle.Equals("Remote Desktop Connection") /*|| w < 400*/) /* RDP master process or auth dialog */
-                    {
-                        System.Threading.Thread.Sleep(5000);
-                        IntPtr childWin = NativeMethods.GetWindow(winCandidate, NativeMethods.GetWindowCmd.GW_CHILD);
-                        Log.Info("Got child win: " + ((int)childWin));
-                        StringBuilder childWinTitleBuf = new StringBuilder(256);
-                        int childWinTitleLen = NativeMethods.GetWindowText(childWin, childWinTitleBuf, childWinTitleBuf.Capacity - 1);
-                        if (childWinTitleLen > 0 && childWinTitleBuf.ToString().Contains(" - Remote Desktop Connection"))
-                        {
-                            this.b_AppWinFinal = true;
-                            Log.Info("Updated transitional child window handle to " + ((int)childWin) + ". Win size is " + w + "x" + h + ". Title is: " + this.m_Process.MainWindowTitle);
-                            this.m_AppWin = childWin;
-                        }
-                        else
-                        {
-                            //this.b_AppWinFinal = true;
-                            Log.Info("Updated transitional window handle to " + ((int)winCandidate) + ". Win size is " + w + "x" + h + ". Title is: " + this.m_Process.MainWindowTitle);
-                            this.m_AppWin = winCandidate;
-                        }
-                    }
-                    else
-                    {
-                        Log.Info("Updated transitional window handle 2 to " + ((int)winCandidate) + ". Win size is " + w + "x" + h + ". Title is: " + this.m_Process.MainWindowTitle);
-                        this.m_AppWin = winCandidate;
-                    }
-                    break;
-                default:
-                    this.b_AppWinFinal = true;
-                    bNeedsUpdate = false;
-                    break;
-            }
-
-            if (this.b_AppWinFinal && bNeedsUpdate)
-            {
-                this.AttachToWindow(); /* Must attach to the window */
-
-                if (this.Visible && this.m_Created && this.ExternalProcessCaptured)
-                {
-                    // Move the child so it's located over the parent
-                    this.MoveWindow("UpdateWindow");
-                    
-                    if (RefocusOnVisChanged && NativeMethods.GetForegroundWindow() != this.m_AppWin)
-                    {
-                        this.BeginInvoke(new MethodInvoker(delegate { this.ReFocusPuTTY("UpdateWindow"); }));
-                    }
-                }
             }
         }
 


### PR DESCRIPTION
There is a long time outstanding issue, there during launch some PuTTY processes could stay detached(Float state), and nothing would connect them back in the same SP run. Chances of this increased with the number of open sessions and was almost non-existent below 10. However for ~20 sessions, yet still quite rare it could occur, requiring one SP restart at most cases.
So I ignored the issue for years.

However, recently I've upgraded my VM Windows 10 from 1809 to new 21H2, and now the issue became interminent(9/10 runs SP loads with this issue). I've tested by reverting the VM snapshot to old Win10, there SP worked well again.
So i started to research into this and it was long process. Today I found that some extra delay between Start and WaitForInputHandle calls, had a positive effect on this and continued to investigate. I've updated the children start code to load it maximized initially(As AttachToWindow always maximizes it later), and SP now always starts properly(Without extra delay).
So it seems like timing issue of waiting for input and Putty window possibly starting minimized sometimes, or something like that.