### PR TITLE
Added Python scripting capability

### DIFF
--- a/.idea/.idea.SuperPutty/.idea/.gitignore
+++ b/.idea/.idea.SuperPutty/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/modules.xml
+/contentModel.xml
+/.idea.SuperPutty.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.SuperPutty/.idea/.name
+++ b/.idea/.idea.SuperPutty/.idea/.name
@@ -1,0 +1,1 @@
+SuperPutty

--- a/.idea/.idea.SuperPutty/.idea/encodings.xml
+++ b/.idea/.idea.SuperPutty/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.SuperPutty/.idea/indexLayout.xml
+++ b/.idea/.idea.SuperPutty/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.SuperPutty/.idea/vcs.xml
+++ b/.idea/.idea.SuperPutty/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/SuperPutty.sln.DotSettings.user
+++ b/SuperPutty.sln.DotSettings.user
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Int64 x:Key="/Default/Environment/Hierarchy/Build/BuildTool/MsbuildVersion/@EntryValue">1114112</s:Int64>
+	<s:String x:Key="/Default/Environment/Hierarchy/Build/BuildTool/CustomBuildToolPath/@EntryValue">C:\Users\reggi\AppData\Local\JetBrains\BuildTools\MSBuild\Current\Bin\MSBuild.exe</s:String></wpf:ResourceDictionary>

--- a/SuperPutty/SuperPuTTY.cs
+++ b/SuperPutty/SuperPuTTY.cs
@@ -529,8 +529,15 @@ namespace SuperPutty
                         if (!String.IsNullOrEmpty(script))
                         {
                             ExecuteScriptEventArgs scriptArgs = new ExecuteScriptEventArgs() { Script = script, Handle = panel.AppPanel.AppWindowHandle };
-                            SPSL.BeginExecuteScript(scriptArgs);
-                        }
+                            
+                            if (scriptArgs.IsPython)
+                            {
+                                SPSL.BeginExecutePythonScript(scriptArgs, session);
+                            }
+                            else
+                            {
+                                SPSL.BeginExecuteScript(scriptArgs);
+                            }                        }
                     }
                 } catch (InvalidOperationException ex)
                 {

--- a/SuperPutty/SuperPutty.csproj
+++ b/SuperPutty/SuperPutty.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SuperPutty</RootNamespace>
     <AssemblyName>SuperPutty</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -33,6 +33,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -65,8 +66,36 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="IronPython, Version=2.7.11.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1">
+      <HintPath>..\packages\IronPython.2.7.11\lib\net45\IronPython.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="IronPython.Modules, Version=2.7.11.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1">
+      <HintPath>..\packages\IronPython.2.7.11\lib\net45\IronPython.Modules.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="IronPython.SQLite, Version=2.7.11.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1">
+      <HintPath>..\packages\IronPython.2.7.11\lib\net45\IronPython.SQLite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="IronPython.Wpf, Version=2.7.11.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1">
+      <HintPath>..\packages\IronPython.2.7.11\lib\net45\IronPython.Wpf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="log4net, Version=2.0.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.13\lib\net45\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Dynamic, Version=1.3.0.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.3.0\lib\net45\Microsoft.Dynamic.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Scripting, Version=1.3.0.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.3.0\lib\net45\Microsoft.Scripting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Scripting.Metadata, Version=1.3.0.0, Culture=neutral, PublicKeyToken=7f709c5b713576e1">
+      <HintPath>..\packages\DynamicLanguageRuntime.1.3.0\lib\net45\Microsoft.Scripting.Metadata.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Renci.SshNet, Version=2020.0.1.0, Culture=neutral, PublicKeyToken=1cee9f8bde3db106, processorArchitecture=MSIL">

--- a/SuperPutty/dlgScriptEditor.cs
+++ b/SuperPutty/dlgScriptEditor.cs
@@ -80,7 +80,7 @@ namespace SuperPutty
     {
         /// <summary>A string containing a list of commands to be sent to open terminal sessions</summary>
         public string Script { get; set; }
-        /// <summary>True if the script should be handled by script parser</summary>
+        /// <summary>True if the script should be handled by SPSL script parser</summary>
         public bool IsSPSL {
             get
             {
@@ -92,6 +92,18 @@ namespace SuperPutty
             }
         }
 
+        /// <summary>True if the script should be handled by Python script parser</summary>
+        public bool IsPython {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.Script)
+                    && this.Script.StartsWith("#!/bin/python"))
+                    return true;
+                else
+                    return false;
+            }
+        }
+        
         /// <summary>If set to the handle of a window, script will be restricted to the specified session only.</summary>
         public IntPtr Handle { get; set; }
     }

--- a/SuperPutty/packages.config
+++ b/SuperPutty/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="DockPanelSuite" version="3.1.0" targetFramework="net45" />
   <package id="DockPanelSuite.ThemeVS2005" version="3.1.0" targetFramework="net45" />
+  <package id="DynamicLanguageRuntime" version="1.3.0" targetFramework="net452" />
+  <package id="IronPython" version="2.7.11" targetFramework="net452" />
   <package id="log4net" version="2.0.13" targetFramework="net45" />
   <package id="Microsoft.VisualBasic" version="10.3.0" targetFramework="net45" />
   <package id="SSH.NET" version="2020.0.1" targetFramework="net45" />

--- a/SuperPuttyUnitTests/SuperPuttyUnitTests.csproj
+++ b/SuperPuttyUnitTests/SuperPuttyUnitTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SuperPuttyUnitTests</RootNamespace>
     <AssemblyName>SuperPuttyUnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
I added the capability to script via an embedded IronPython interpreter.  Here are examples of two equivalent SPSL and Python scripts:

SPSL
-----
#!/bin/spsl

PROMPT What is your password?
SENDLINE ls -ltr
SENDCHAR w
SENDKEY {ENTER}
SLEEP 10000 
OPENSESSION TestTwo

Python
-------
#!/bin/python

PROMPT("What is your password?")
SENDLINE("ls -ltr")
SENDCHAR("w")
SENDKEY("{ENTER}")
SLEEP(10000)
OPENSESSION("TestTwo")

In addition, the Python interpreter exposes the current SessionData object via a locally scoped variable, making scripts like this possible:

if (Session.SessionName == "Test"):
    SENDLINE("echo 'Session name: " + Session.SessionName + "'")
    SENDLINE("echo 'Session ID: " + Session.SessionId + "'")
    SENDLINE("echo 'Session host: " + Session.Host + "'")
    SENDLINE("echo 'Session protocol: " + str(Session.Proto) + "'")
    SENDLINE("echo 'Session port: " + str(Session.Port) + "'")

With the addition of a full Python interpreter the SuperPutty user can create scripts which include not only the "built-in" SPSL commands but can also use any amount of custom logic. 

The Python scripting capability has been added to both scripts executed on terminal creation as well as the script entry dialog.
