### PR TITLE
Add putty.ini support

### DIFF
--- a/SuperPutty/SuperPutty.csproj
+++ b/SuperPutty/SuperPutty.csproj
@@ -65,6 +65,9 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="INIFileParser, Version=2.5.2.0, Culture=neutral, PublicKeyToken=79af7b307b65cf3c, processorArchitecture=MSIL">
+      <HintPath>..\packages\ini-parser.2.5.2\lib\net20\INIFileParser.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.13\lib\net45\log4net.dll</HintPath>
     </Reference>

--- a/SuperPutty/packages.config
+++ b/SuperPutty/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="DockPanelSuite" version="3.1.0" targetFramework="net45" />
   <package id="DockPanelSuite.ThemeVS2005" version="3.1.0" targetFramework="net45" />
+  <package id="ini-parser" version="2.5.2" targetFramework="net45" />
   <package id="log4net" version="2.0.13" targetFramework="net45" />
   <package id="Microsoft.VisualBasic" version="10.3.0" targetFramework="net45" />
   <package id="SSH.NET" version="2020.0.1" targetFramework="net45" />


### PR DESCRIPTION
Hi, I've recently noticed your SuperPuTTY program.
Tab support is very useful.  Thank you for publishing this tool.

But SuperPuTTY doesn't support "putty.ini".

There are several putty forks that use putty.ini to store settings instead of registry.
(e.g. [PuTTYrv](https://www.ranvis.com/putty.en), [iceiv+putty](https://ice-hotmint-com.translate.goog/putty/?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=ja&_x_tr_pto=wapp) and original putty.ini support is from [gotta-ni buiid](https://web.archive.org/web/20171226103843/http://yebisuya.dip.jp:80/Software/PuTTY/))

I think they are quite popular in Japanese.

I implemented putty.ini support like this.
Could you please take a look?

p.s.
One known problem exists.

Used ini-parser(https://github.com/rickyah/ini-parser) library is not so robust.
It doesn't allow loading ini file which has "duped" section exists.
Implement additional error handling or add forgive multiple section option to ini-parser for better supporting.